### PR TITLE
change message when chunk is skipped at destination for copy

### DIFF
--- a/src/duplicacy_backupmanager.go
+++ b/src/duplicacy_backupmanager.go
@@ -1677,7 +1677,7 @@ func (manager *BackupManager) CopySnapshots(otherManager *BackupManager, snapsho
             chunkUploader.StartChunk(newChunk, chunkIndex)
             totalCopied++
         } else {
-            LOG_INFO("SNAPSHOT_COPY", "Chunk %s (%d/%d) exists at the destination.", chunkID, chunkIndex, len(chunks))
+            LOG_INFO("SNAPSHOT_COPY", "Chunk %s (%d/%d) skipped at the destination", chunkID, chunkIndex, len(chunks))
             totalSkipped++
         }
     }


### PR DESCRIPTION
The message when a chunk is optimized and skipped at the destination because it's referenced in one or more destination snapshots is too similar to the message when the destination is checked and finds that the chunk physically exists.

This patch clarifies when a chunk is skipped vs physically found at the destination when an attempt to upload the chunk is performed.