### PR TITLE
fix prune bug when last snapshot is removed for issue #182

### DIFF
--- a/src/duplicacy_snapshotmanager.go
+++ b/src/duplicacy_snapshotmanager.go
@@ -2065,7 +2065,7 @@ func (manager *SnapshotManager) PruneSnapshots(selfID string, snapshotID string,
                          snapshot.ID, snapshot.Revision)
             }
             manager.snapshotCache.DeleteFile(0, snapshotPath)
-            fmt.Fprintf(logFile, "Deleted snapshot %s at revision %d\n", snapshot.ID, snapshot.Revision)
+            fmt.Fprintf(logFile, "Deleted cached snapshot %s at revision %d\n", snapshot.ID, snapshot.Revision)
         }
     }
 
@@ -2074,12 +2074,16 @@ func (manager *SnapshotManager) PruneSnapshots(selfID string, snapshotID string,
                  "No fossil collection has been created since deleted snapshots did not reference any unique chunks")
     }
 
-    var latestSnapshot *Snapshot
+    var latestSnapshot *Snapshot = nil
     if len(allSnapshots[selfID]) > 0 {
         latestSnapshot = allSnapshots[selfID][len(allSnapshots[selfID]) - 1]
     }
 
-    manager.CleanSnapshotCache(latestSnapshot, allSnapshots)
+    if latestSnapshot != nil && !latestSnapshot.Flag {
+        manager.CleanSnapshotCache(latestSnapshot, allSnapshots)
+    } else {
+        manager.CleanSnapshotCache(nil, allSnapshots)
+    }
 
     return true
 }


### PR DESCRIPTION
This prevents the bug when CleanSnapshotCache is called and the last snapshot pointer is not nil. Please review and let me know if you had a different approach in mind how to resolve this.