### PR TITLE
add regex matching to include/exclude filters

### DIFF
--- a/duplicacy/duplicacy_main.go
+++ b/duplicacy/duplicacy_main.go
@@ -679,6 +679,8 @@ func restoreRepository(context *cli.Context) {
     var patterns [] string
     for _, pattern := range context.Args() {
 
+        pattern = strings.TrimSpace(pattern)
+
         for strings.HasPrefix(pattern, "--") {
             pattern = pattern[1:]
         }
@@ -687,12 +689,19 @@ func restoreRepository(context *cli.Context) {
             pattern = pattern[1:]
         }
 
-        if pattern[0] != '+' && pattern[0] != '-' {
+        if duplicacy.IsUnspecifiedFilter(pattern) {
             pattern = "+" + pattern
         }
 
-        if pattern == "+" || pattern == "-" {
+        if duplicacy.IsEmptyFilter(pattern) {
             continue
+        }
+
+        if strings.HasPrefix(pattern, "i:") || strings.HasPrefix(pattern, "e:") {
+            valid, err := duplicacy.IsValidRegex(pattern[2:])
+            if  !valid || err != nil {
+                duplicacy.LOG_ERROR("SNAPSHOT_FILTER", "Invalid regular expression encountered for filter: \"%s\", error: %v", pattern, err)
+            }
         }
 
         patterns = append(patterns, pattern)

--- a/src/duplicacy_backupmanager.go
+++ b/src/duplicacy_backupmanager.go
@@ -761,6 +761,7 @@ func (manager *BackupManager) Restore(top string, revision int, inPlace bool, qu
         for _, file := range remoteSnapshot.Files {
 
             if MatchPath(file.Path, patterns) {
+                LOG_TRACE("RESTORE_INCLUDE", "Include %s", file.Path)
                 includedFiles = append(includedFiles, file)
             } else {
                 LOG_TRACE("RESTORE_EXCLUDE", "Exclude %s", file.Path)

--- a/src/duplicacy_snapshot.go
+++ b/src/duplicacy_snapshot.go
@@ -67,7 +67,7 @@ func CreateSnapshotFromDirectory(id string, top string) (snapshot *Snapshot, ski
     }
 
     var patterns []string
-    
+
     patternFile, err := ioutil.ReadFile(path.Join(GetDuplicacyPreferencePath(), "filters"))
     if err == nil {
         for _, pattern := range strings.Split(string(patternFile), "\n") {
@@ -76,12 +76,23 @@ func CreateSnapshotFromDirectory(id string, top string) (snapshot *Snapshot, ski
                 continue
             }
 
-            if pattern[0] != '+' && pattern[0] != '-' {
+            if pattern[0] == '#' {
+                continue
+            }
+
+            if IsUnspecifiedFilter(pattern) {
                 pattern = "+" + pattern
             }
 
-            if pattern == "+" || pattern == "-" {
+            if IsEmptyFilter(pattern) {
                 continue
+            }
+
+            if strings.HasPrefix(pattern, "i:") || strings.HasPrefix(pattern, "e:") {
+                valid, err := IsValidRegex(pattern[2:])
+                if  !valid || err != nil {
+                    LOG_ERROR("SNAPSHOT_FILTER", "Invalid regular expression encountered for filter: \"%s\", error: %v", pattern, err)
+                }
             }
 
             patterns = append(patterns, pattern)


### PR DESCRIPTION
Implement regular expression support for enhancement request #175. Can be used to replace existing filter functionality or in conjunction with existing functionality.

Regex include filters are preceded with "i:" and regex exclude filters preceded with "e:". Both backup (.duplicacy/filters) and restore command line arguments have been tested/verified.

Please review and consider for adoption to duplicacy. Thanks!