### PR TITLE
store compiled regex patterns for performance optimization

### DIFF
--- a/duplicacy/duplicacy_main.go
+++ b/duplicacy/duplicacy_main.go
@@ -708,6 +708,8 @@ func restoreRepository(context *cli.Context) {
 
     }
 
+    duplicacy.LOG_DEBUG("REGEX_DEBUG", "There are %d compiled regular expressions stored", len(duplicacy.RegexMap))
+
     storage.SetRateLimits(context.Int("limit-rate"), 0)
     backupManager := duplicacy.CreateBackupManager(preference.SnapshotID, storage, repository, password)
     duplicacy.SavePassword(*preference, "password", password)

--- a/src/duplicacy_snapshot.go
+++ b/src/duplicacy_snapshot.go
@@ -98,6 +98,8 @@ func CreateSnapshotFromDirectory(id string, top string) (snapshot *Snapshot, ski
             patterns = append(patterns, pattern)
         }
 
+        LOG_DEBUG("REGEX_DEBUG", "There are %d compiled regular expressions stored", len(RegexMap))
+
         LOG_INFO("SNAPSHOT_FILTER", "Loaded %d include/exclude pattern(s)", len(patterns))
 
         if IsTracing() {


### PR DESCRIPTION
Hi, here's my attempt at optimizing the regex filter performance. It works as follows:

1. When a filter is first compiled to verify its validity, the Regexp pointer returned by the compile is stored in a map for future reference.

2. MatchPath is updated to look for the presence of a compiled regex in the map. It uses it if stored and will compile/use the regex pattern if not found in the map, although in testing, I did not encounter a scenario where the already compiled regex was not available in the map.

3. I had no idea where/how to store the compiled regex map, so I created a new src/duplicacy_regex.go that simply has the variable declaration for the map. I suspect this is the go equivalent of a global variable, which I am not in the habit of doing, but I was not able to figure out where to store the map that would be accessible since the MatchPath and IsValidRegex are utlity routines that are not associated with an object ptr, etc.

4. Before storing a new compiled regex to the map, I verify if the map already contains the compiled regex and LOG_WARN if the entry already exists. This should perhaps be a LOG_ERROR, as the implication is that the user has duplicate include or exclude filters (minus the prefix). I decided on the warning because I felt that even if the user has duplicate filters, matching will stop on the first match whether it's an include or exclude filter, so the fact that there's another filter statement later in the filters file, I would not change the match/nomatch. 

5. I left in multiple LOG_DEBUG calls, which I would probably remove if you are OK with the patch, just let me know and I'll remove those debug statements.

6. I tested this for both backup/restore and in my testing, the compiled regex statements are used successfully, avoiding having to compile the regex for each comparison, which can of course be frequent for large filesystems.

If there's a better way to accomplish this, any input you can provide I'd be happy to implement the way you want.