### PR TITLE
print additional, table-formatted stats for CHECK

### DIFF
--- a/duplicacy/duplicacy_main.go
+++ b/duplicacy/duplicacy_main.go
@@ -808,12 +808,13 @@ func checkSnapshots(context *cli.Context) {
     }
 
     showStatistics := context.Bool("stats")
+    showTabular := context.Bool("tabular")
     checkFiles := context.Bool("files")
     searchFossils := context.Bool("fossils")
     resurrect := context.Bool("resurrect")
 
     backupManager.SetupSnapshotCache(preference.Name)
-    backupManager.SnapshotManager.CheckSnapshots(id, revisions, tag, showStatistics, checkFiles, searchFossils, resurrect)
+    backupManager.SnapshotManager.CheckSnapshots(id, revisions, tag, showStatistics, showTabular, checkFiles, searchFossils, resurrect)
 
     runScript(context, preference.Name, "post")
 }
@@ -1354,6 +1355,10 @@ func main() {
                 cli.BoolFlag {
                     Name:  "stats",
                     Usage: "show deduplication statistics (imply -all and all revisions)",
+                },
+                cli.BoolFlag {
+                    Name:  "tabular",
+                    Usage: "show tabular usage and deduplication statistics (imply -stats, -all, and all revisions)",
                 },
                 cli.StringFlag {
                     Name: "storage",

--- a/src/duplicacy_snapshotmanager.go
+++ b/src/duplicacy_snapshotmanager.go
@@ -896,90 +896,145 @@ func (manager *SnapshotManager) CheckSnapshots(snapshotID string, revisionsToChe
         snapshotIDIndex += 1
     }
 
+    if showTabular {
+        manager.ShowStatisticsTabular(snapshotMap, chunkSizeMap, chunkUniqueMap, chunkSnapshotMap)
+    } else if showStatistics {
+        manager.ShowStatistics(snapshotMap, chunkSizeMap, chunkUniqueMap, chunkSnapshotMap)
+    }
 
-    if showStatistics {
-        tableBuffer := new(bytes.Buffer)
-        tableWriter := tabwriter.NewWriter(tableBuffer, 0, 0, 1, ' ', tabwriter.AlignRight|tabwriter.Debug)
+    return true
+}
 
-        for snapshotID, snapshotList := range snapshotMap {
-            fmt.Fprintln(tableWriter, "")
-            fmt.Fprintln(tableWriter, " snap \trev \t \tfiles \tbytes \tchunks \tbytes \tuniq \tbytes \tnew \tbytes \t")
-            snapshotChunks := make(map[string]bool)
+// Print snapshot and revision statistics
+func (manager *SnapshotManager) ShowStatistics(snapshotMap map[string] [] *Snapshot, chunkSizeMap map[string]int64, chunkUniqueMap map[string]bool, 
+                                               chunkSnapshotMap map[string]int) {
+    for snapshotID, snapshotList := range snapshotMap {
 
-            earliestSeenChunks := make(map[string]int)
+        snapshotChunks := make(map[string]bool)
 
-            for _, snapshot := range snapshotList {
-                for _, chunkID := range manager.GetSnapshotChunks(snapshot) {
-                    if earliestSeenChunks[chunkID] == 0 {
-                        earliestSeenChunks[chunkID] = math.MaxInt64
-                    }
-                    earliestSeenChunks[chunkID] = MinInt(earliestSeenChunks[chunkID], snapshot.Revision)
+        for _, snapshot := range snapshotList {
+
+            chunks := make(map[string]bool)
+            for _, chunkID := range manager.GetSnapshotChunks(snapshot) {
+                chunks[chunkID] = true
+                snapshotChunks[chunkID] = true
+            }
+
+            var totalChunkSize int64
+            var uniqueChunkSize int64
+
+            for chunkID, _ := range chunks {
+                chunkSize := chunkSizeMap[chunkID]
+                totalChunkSize += chunkSize
+                if chunkUniqueMap[chunkID] {
+                    uniqueChunkSize += chunkSize
                 }
             }
 
-            for _, snapshot := range snapshotList {
+            files := ""
+            if snapshot.FileSize != 0 && snapshot.NumberOfFiles != 0 {
+                files = fmt.Sprintf("%d files (%s bytes), ", snapshot.NumberOfFiles, PrettyNumber(snapshot.FileSize))
+            }
+            LOG_INFO("SNAPSHOT_CHECK", "Snapshot %s at revision %d: %s%s total chunk bytes, %s unique chunk bytes",
+                     snapshot.ID, snapshot.Revision, files, PrettyNumber(totalChunkSize), PrettyNumber(uniqueChunkSize))
+        }
 
-                chunks := make(map[string]bool)
-                for _, chunkID := range manager.GetSnapshotChunks(snapshot) {
-                    chunks[chunkID] = true
-                    snapshotChunks[chunkID] = true
+        var totalChunkSize int64
+        var uniqueChunkSize int64
+        for chunkID, _ := range snapshotChunks {
+            chunkSize := chunkSizeMap[chunkID]
+            totalChunkSize += chunkSize
+
+            if chunkSnapshotMap[chunkID] != -1 {
+                uniqueChunkSize += chunkSize
+            }
+        }
+        LOG_INFO("SNAPSHOT_CHECK", "Snapshot %s all revisions: %s total chunk bytes, %s unique chunk bytes",
+                snapshotID, PrettyNumber(totalChunkSize), PrettyNumber(uniqueChunkSize))
+    }
+}
+
+// Print snapshot and revision statistics in tabular format
+func (manager *SnapshotManager) ShowStatisticsTabular(snapshotMap map[string] [] *Snapshot, chunkSizeMap map[string]int64, chunkUniqueMap map[string]bool, 
+                                               chunkSnapshotMap map[string]int) {
+    tableBuffer := new(bytes.Buffer)
+    tableWriter := tabwriter.NewWriter(tableBuffer, 0, 0, 1, ' ', tabwriter.AlignRight|tabwriter.Debug)
+
+    for snapshotID, snapshotList := range snapshotMap {
+        fmt.Fprintln(tableWriter, "")
+        fmt.Fprintln(tableWriter, " snap \trev \t \tfiles \tbytes \tchunks \tbytes \tuniq \tbytes \tnew \tbytes \t")
+        snapshotChunks := make(map[string]bool)
+
+        earliestSeenChunks := make(map[string]int)
+
+        for _, snapshot := range snapshotList {
+            for _, chunkID := range manager.GetSnapshotChunks(snapshot) {
+                if earliestSeenChunks[chunkID] == 0 {
+                    earliestSeenChunks[chunkID] = math.MaxInt64
                 }
+                earliestSeenChunks[chunkID] = MinInt(earliestSeenChunks[chunkID], snapshot.Revision)
+            }
+        }
 
-                var totalChunkSize int64
-                var uniqueChunkSize int64
-                var totalChunkCount int64
-                var uniqueChunkCount int64
-                var newChunkCount int64
-                var newChunkSize int64
+        for _, snapshot := range snapshotList {
 
-                for chunkID, _ := range chunks {
-                    chunkSize := chunkSizeMap[chunkID]
-                    totalChunkSize += chunkSize
-                    totalChunkCount += 1
-                    if earliestSeenChunks[chunkID] == snapshot.Revision {
-                        newChunkCount += 1
-                        newChunkSize += chunkSize
-                    }
-                    if chunkUniqueMap[chunkID] {
-                        uniqueChunkSize += chunkSize
-                        uniqueChunkCount += 1
-                    }
-                }
-
-                files := " \t "
-                if snapshot.FileSize != 0 && snapshot.NumberOfFiles != 0 {
-                    files = fmt.Sprintf("%d \t%s", snapshot.NumberOfFiles, PrettyNumber(snapshot.FileSize))
-                }
-                creationTime := time.Unix(snapshot.StartTime, 0).Format("2006-01-02 15:04")
-                fmt.Fprintln(tableWriter, fmt.Sprintf(
-                        "%s \t%d \t@ %s %5s \t%s \t%d \t%s \t%d \t%s \t%d \t%s \t", 
-                        snapshotID, snapshot.Revision, creationTime, snapshot.Options, files, totalChunkCount, PrettyNumber(totalChunkSize), uniqueChunkCount, PrettyNumber(uniqueChunkSize), newChunkCount, PrettyNumber(newChunkSize)))
+            chunks := make(map[string]bool)
+            for _, chunkID := range manager.GetSnapshotChunks(snapshot) {
+                chunks[chunkID] = true
+                snapshotChunks[chunkID] = true
             }
 
             var totalChunkSize int64
             var uniqueChunkSize int64
             var totalChunkCount int64
             var uniqueChunkCount int64
-            for chunkID, _ := range snapshotChunks {
+            var newChunkCount int64
+            var newChunkSize int64
+
+            for chunkID, _ := range chunks {
                 chunkSize := chunkSizeMap[chunkID]
                 totalChunkSize += chunkSize
                 totalChunkCount += 1
-
-                if chunkSnapshotMap[chunkID] != -1 {
+                if earliestSeenChunks[chunkID] == snapshot.Revision {
+                    newChunkCount += 1
+                    newChunkSize += chunkSize
+                }
+                if chunkUniqueMap[chunkID] {
                     uniqueChunkSize += chunkSize
                     uniqueChunkCount += 1
                 }
             }
+
+            files := " \t "
+            if snapshot.FileSize != 0 && snapshot.NumberOfFiles != 0 {
+                files = fmt.Sprintf("%d \t%s", snapshot.NumberOfFiles, PrettyNumber(snapshot.FileSize))
+            }
+            creationTime := time.Unix(snapshot.StartTime, 0).Format("2006-01-02 15:04")
             fmt.Fprintln(tableWriter, fmt.Sprintf(
-                    "%s \tall \t \t \t \t%d \t%s \t%d \t%s \t \t \t", 
-                    snapshotID, totalChunkCount, PrettyNumber(totalChunkSize), uniqueChunkCount, PrettyNumber(uniqueChunkSize)))
+                    "%s \t%d \t@ %s %5s \t%s \t%d \t%s \t%d \t%s \t%d \t%s \t", 
+                    snapshotID, snapshot.Revision, creationTime, snapshot.Options, files, totalChunkCount, PrettyNumber(totalChunkSize), uniqueChunkCount, PrettyNumber(uniqueChunkSize), newChunkCount, PrettyNumber(newChunkSize)))
         }
-        tableWriter.Flush()
-        LOG_INFO("SNAPSHOT_CHECK", tableBuffer.String())
+
+        var totalChunkSize int64
+        var uniqueChunkSize int64
+        var totalChunkCount int64
+        var uniqueChunkCount int64
+        for chunkID, _ := range snapshotChunks {
+            chunkSize := chunkSizeMap[chunkID]
+            totalChunkSize += chunkSize
+            totalChunkCount += 1
+
+            if chunkSnapshotMap[chunkID] != -1 {
+                uniqueChunkSize += chunkSize
+                uniqueChunkCount += 1
+            }
+        }
+        fmt.Fprintln(tableWriter, fmt.Sprintf(
+                "%s \tall \t \t \t \t%d \t%s \t%d \t%s \t \t \t", 
+                snapshotID, totalChunkCount, PrettyNumber(totalChunkSize), uniqueChunkCount, PrettyNumber(uniqueChunkSize)))
     }
-
-    return true
-
+    tableWriter.Flush()
+    LOG_INFO("SNAPSHOT_CHECK", tableBuffer.String())
 }
 
 // ConvertSequence converts a sequence of chunk hashes into a sequence of chunk ids.

--- a/src/duplicacy_snapshotmanager.go
+++ b/src/duplicacy_snapshotmanager.go
@@ -903,7 +903,7 @@ func (manager *SnapshotManager) CheckSnapshots(snapshotID string, revisionsToChe
 
         for snapshotID, snapshotList := range snapshotMap {
             fmt.Fprintln(tableWriter, "")
-            fmt.Fprintln(tableWriter, " files \tbytes \tchunks \tbytes \tuniq \tbytes \tnew \tbytes \tsnap \trev \t \t")
+            fmt.Fprintln(tableWriter, " snap \trev \t \tfiles \tbytes \tchunks \tbytes \tuniq \tbytes \tnew \tbytes \t")
             snapshotChunks := make(map[string]bool)
 
             earliestSeenChunks := make(map[string]int)
@@ -951,13 +951,9 @@ func (manager *SnapshotManager) CheckSnapshots(snapshotID string, revisionsToChe
                     files = fmt.Sprintf("%d \t%s", snapshot.NumberOfFiles, PrettyNumber(snapshot.FileSize))
                 }
                 creationTime := time.Unix(snapshot.StartTime, 0).Format("2006-01-02 15:04")
-                tagWithSpace := ""
-                if len(snapshot.Tag) > 0 {
-                    tagWithSpace = snapshot.Tag + " "
-                }
                 fmt.Fprintln(tableWriter, fmt.Sprintf(
-                        "%s \t%d \t%s \t%d \t%s \t%d \t%s \t%s \t%d \t@ %s %s%s \t", 
-                        files, totalChunkCount, PrettyNumber(totalChunkSize), uniqueChunkCount, PrettyNumber(uniqueChunkSize), newChunkCount, PrettyNumber(newChunkSize), snapshotID, snapshot.Revision, creationTime, tagWithSpace, snapshot.Options))
+                        "%s \t%d \t@ %s %5s \t%s \t%d \t%s \t%d \t%s \t%d \t%s \t", 
+                        snapshotID, snapshot.Revision, creationTime, snapshot.Options, files, totalChunkCount, PrettyNumber(totalChunkSize), uniqueChunkCount, PrettyNumber(uniqueChunkSize), newChunkCount, PrettyNumber(newChunkSize)))
             }
 
             var totalChunkSize int64
@@ -975,8 +971,8 @@ func (manager *SnapshotManager) CheckSnapshots(snapshotID string, revisionsToChe
                 }
             }
             fmt.Fprintln(tableWriter, fmt.Sprintf(
-                    " \t \t%d \t%s \t%d \t%s \t \t \t%s \tall \t \t", 
-                    totalChunkCount, PrettyNumber(totalChunkSize), uniqueChunkCount, PrettyNumber(uniqueChunkSize), snapshotID))
+                    "%s \tall \t \t \t \t%d \t%s \t%d \t%s \t \t \t", 
+                    snapshotID, totalChunkCount, PrettyNumber(totalChunkSize), uniqueChunkCount, PrettyNumber(uniqueChunkSize)))
         }
         tableWriter.Flush()
         LOG_INFO("SNAPSHOT_CHECK", tableBuffer.String())

--- a/src/duplicacy_snapshotmanager.go
+++ b/src/duplicacy_snapshotmanager.go
@@ -748,7 +748,7 @@ func (manager *SnapshotManager) ListSnapshots(snapshotID string, revisionsToList
 }
 
 // ListSnapshots shows the information about a snapshot.
-func (manager *SnapshotManager) CheckSnapshots(snapshotID string, revisionsToCheck []int, tag string, showStatistics bool,
+func (manager *SnapshotManager) CheckSnapshots(snapshotID string, revisionsToCheck []int, tag string, showStatistics bool, showTabular bool,
                                               checkFiles bool, searchFossils bool, resurrect bool) bool {
 
     LOG_DEBUG("LIST_PARAMETERS", "id: %s, revisions: %v, tag: %s, showStatistics: %t, checkFiles: %t, searchFossils: %t, resurrect: %t",

--- a/src/duplicacy_snapshotmanager.go
+++ b/src/duplicacy_snapshotmanager.go
@@ -913,7 +913,7 @@ func (manager *SnapshotManager) CheckSnapshots(snapshotID string, revisionsToChe
                     if earliestSeenChunks[chunkID] == 0 {
                         earliestSeenChunks[chunkID] = math.MaxInt64
                     }
-                    earliestSeenChunks[chunkID] = min(earliestSeenChunks[chunkID], snapshot.Revision)
+                    earliestSeenChunks[chunkID] = MinInt(earliestSeenChunks[chunkID], snapshot.Revision)
                 }
             }
 
@@ -981,14 +981,6 @@ func (manager *SnapshotManager) CheckSnapshots(snapshotID string, revisionsToChe
     return true
 
 }
-
-func min(x, y int) int {
-    if x < y {
-        return x
-    }
-    return y
-}
-
 
 // ConvertSequence converts a sequence of chunk hashes into a sequence of chunk ids.
 func (manager *SnapshotManager) ConvertSequence(sequence []string) (result []string) {

--- a/src/duplicacy_utils.go
+++ b/src/duplicacy_utils.go
@@ -427,3 +427,10 @@ func AtoSize(sizeString string) (int) {
 
     return size
 }
+
+func MinInt(x, y int) (int) {
+    if x < y {
+        return x
+    }
+    return y
+}


### PR DESCRIPTION
As I discussed in #178, I've extended the "check -stats" output to include additional details. I could see improving the column names to more clearly describe what they contain. Reading across: revision file count and bytes, revision chunk count and bytes, unique revision chunk count and bytes, chunk count and bytes introduced in this revision, snapshot and revision information.

An example of the tabular output:
```
  files |   bytes | chunks |   bytes | uniq |   bytes | new |  bytes |       snap | rev |                          |
        |         |      2 |      24 |    0 |       0 |   2 |     24 | snapshot-2 |   1 | @ 2017-09-15 22:46 -hash |
      1 |  6,933K |      6 |  6,960K |    3 |     435 |   6 | 6,960K | snapshot-2 |   2 | @ 2017-09-15 22:46 -hash |
      2 | 13,866K |      9 | 13,921K |    3 |     766 |   6 | 6,961K | snapshot-2 |   3 | @ 2017-09-15 22:46 -hash |
      3 | 20,800K |     11 | 20,882K |    3 |    1012 |   5 | 6,961K | snapshot-2 |   4 | @ 2017-09-15 22:46 -hash |
      4 | 27,733K |     13 | 27,843K |    3 |      1K |   5 | 6,961K | snapshot-2 |   5 | @ 2017-09-15 22:46 -hash |
      2 | 13,866K |      7 | 13,921K |    3 |     617 |   3 |    617 | snapshot-2 |   6 | @ 2017-09-15 22:46 -hash |
        |         |     27 | 27,846K |   19 | 13,925K |     |        | snapshot-2 | all |                          |

  files |   bytes | chunks |   bytes | uniq |   bytes | new |  bytes |       snap | rev |                          |
      1 |  6,933K |      7 |  6,961K |    3 |     510 |   7 | 6,961K | snapshot-1 |   1 | @ 2017-09-15 22:46 -hash |
      2 | 13,866K |      9 | 13,921K |    3 |     765 |   5 | 6,961K | snapshot-1 |   2 | @ 2017-09-15 22:46 -hash |
      3 | 20,800K |     12 | 20,882K |    3 |      1K |   6 | 6,961K | snapshot-1 |   3 | @ 2017-09-15 22:46 -hash |
      3 | 20,800K |     12 | 20,882K |    7 |  6,961K |   7 | 6,961K | snapshot-1 |   4 | @ 2017-09-15 22:46 -hash |
      2 | 13,866K |      9 | 13,921K |    3 |     768 |   6 | 6,961K | snapshot-1 |   5 | @ 2017-09-15 22:46 -hash |
        |         |      2 |      24 |    0 |       0 |   2 |     24 | snapshot-1 |   6 | @ 2017-09-15 22:46 -hash |
        |         |     33 | 34,806K |   25 | 20,885K |     |        | snapshot-1 | all |                          |
```