### PR TITLE
B2 efficiency

### DIFF
--- a/src/duplicacy_b2client.go
+++ b/src/duplicacy_b2client.go
@@ -84,14 +84,14 @@ func (client *B2Client) retry(backoff int, response *http.Response) int {
 func (client *B2Client) call(url string, method string, requestHeaders map[string]string, input interface{}) (io.ReadCloser, http.Header, int64, error) {
 
 	switch method {
-		case http.MethodGet:
-        	break
-        case http.MethodHead:
-        	break
-        case http.MethodPost:
-        	break
-        default:
-        	return nil, nil, 0, fmt.Errorf("unhandled http request method: "+method)
+	case http.MethodGet:
+		break
+	case http.MethodHead:
+		break
+	case http.MethodPost:
+		break
+	default:
+		return nil, nil, 0, fmt.Errorf("unhandled http request method: " + method)
 	}
 
 	var response *http.Response

--- a/src/duplicacy_b2client.go
+++ b/src/duplicacy_b2client.go
@@ -343,11 +343,11 @@ func (client *B2Client) ListFileNames(startFileName string, singleFile bool, inc
 				return nil, fmt.Errorf("b2_download_file_by_name did not return headers")
 			}
 			requiredHeaders := []string{
-				"x-bz-file-id", 
+				"x-bz-file-id",
 				"x-bz-file-name",
 			}
 			missingKeys := []string{}
-			for _,headerKey := range requiredHeaders {
+			for _, headerKey := range requiredHeaders {
 				if "" == responseHeader.Get(headerKey) {
 					missingKeys = append(missingKeys, headerKey)
 				}

--- a/src/duplicacy_b2client.go
+++ b/src/duplicacy_b2client.go
@@ -170,7 +170,8 @@ func (client *B2Client) call(url string, method string, requestHeaders map[strin
 			continue
 		} else if response.StatusCode == 404 {
 			if http.MethodHead == method {
-				return nil, nil, 0, fmt.Errorf("URL request '%s' returned status code %d", url, response.StatusCode)
+				LOG_DEBUG("BACKBLAZE_CALL", "URL request '%s' returned status code %d", url, response.StatusCode)
+				return nil, nil, 0, nil
 			}
 		} else if response.StatusCode == 416 {
 			if http.MethodHead == method {
@@ -340,7 +341,8 @@ func (client *B2Client) ListFileNames(startFileName string, singleFile bool, inc
 
 		if singleFile && !includeVersions {
 			if responseHeader == nil {
-				return nil, fmt.Errorf("b2_download_file_by_name did not return headers")
+				LOG_DEBUG("BACKBLAZE_LIST", "b2_download_file_by_name did not return headers")
+				return []*B2Entry{}, nil
 			}
 			requiredHeaders := []string{
 				"x-bz-file-id",


### PR DESCRIPTION
As discussed in #179 these commits use _b2_download_file_by_name_ instead of _b2_list_file_names_ to retrieve chunk information.
The switch only occurs when a single file is being checked without previous versions (fossils). The call to download doesn't return the "**B2 action**", so the code just supplies "**upload**". This matches the current expectation as a hidden chunk would not be visible to _b2_list_file_names_ either. A fossil would be visible to _b2_list_file_versions_, but that is only called if _includeVersions_ is **true**.
I haven't seen any noticeable impact to run time, but I can see the change in recorded transaction classes on the B2 summary.

The only part that feels outright hacky to me is the switch statement at the top of _call_. I made the http call a HEAD request (B2 could at some point might optimize their API to not charge the requested bytes) and thus needed to pass in a different _input_ paramater. I picked _bool_. This does work, but I wonder if it would be better supported by adding another paramater to specify the request type? Or an enum to make that switch statement more explicit?