### PR TITLE
default to single-dir-nesting for local and SFTP storages

### DIFF
--- a/src/duplicacy_filestorage.go
+++ b/src/duplicacy_filestorage.go
@@ -18,14 +18,14 @@ import (
 type FileStorage struct {
 	RateLimitedStorage
 
-	minimumLevel    int  // The minimum level of directories to dive into before searching for the chunk file.
+	minimumNesting  int  // The minimum level of directories to dive into before searching for the chunk file.
 	isCacheNeeded   bool // Network storages require caching
 	storageDir      string
 	numberOfThreads int
 }
 
 // CreateFileStorage creates a file storage.
-func CreateFileStorage(storageDir string, minimumLevel int, isCacheNeeded bool, threads int) (storage *FileStorage, err error) {
+func CreateFileStorage(storageDir string, minimumNesting int, isCacheNeeded bool, threads int) (storage *FileStorage, err error) {
 
 	var stat os.FileInfo
 
@@ -51,7 +51,7 @@ func CreateFileStorage(storageDir string, minimumLevel int, isCacheNeeded bool, 
 
 	storage = &FileStorage{
 		storageDir:      storageDir,
-		minimumLevel:    minimumLevel,
+		minimumNesting:  minimumNesting,
 		isCacheNeeded:   isCacheNeeded,
 		numberOfThreads: threads,
 	}
@@ -137,7 +137,7 @@ func (storage *FileStorage) FindChunk(threadIndex int, chunkID string, isFossil 
 	}
 
 	for level := 0; level*2 < len(chunkID); level++ {
-		if level >= storage.minimumLevel {
+		if level >= storage.minimumNesting {
 			filePath = path.Join(dir, chunkID[2*level:]) + suffix
 			// Use Lstat() instead of Stat() since 1) Stat() doesn't work for deduplicated disks on Windows and 2) there isn't
 			// really a need to follow the link if filePath is a link.
@@ -159,7 +159,7 @@ func (storage *FileStorage) FindChunk(threadIndex int, chunkID string, isFossil 
 			continue
 		}
 
-		if level < storage.minimumLevel {
+		if level < storage.minimumNesting {
 			// Create the subdirectory if it doesn't exist.
 
 			if err == nil && !stat.IsDir() {

--- a/src/duplicacy_snapshotmanager_test.go
+++ b/src/duplicacy_snapshotmanager_test.go
@@ -95,14 +95,14 @@ func createTestSnapshotManager(testDir string) *SnapshotManager {
 	os.RemoveAll(testDir)
 	os.MkdirAll(testDir, 0700)
 
-	storage, _ := CreateFileStorage(testDir, 2, false, 1)
+	storage, _ := CreateFileStorage(testDir, 1, false, 1)
 	storage.CreateDirectory(0, "chunks")
 	storage.CreateDirectory(0, "snapshots")
 	config := CreateConfig()
 	snapshotManager := CreateSnapshotManager(config, storage)
 
 	cacheDir := path.Join(testDir, "cache")
-	snapshotCache, _ := CreateFileStorage(cacheDir, 2, false, 1)
+	snapshotCache, _ := CreateFileStorage(cacheDir, 1, false, 1)
 	snapshotCache.CreateDirectory(0, "chunks")
 	snapshotCache.CreateDirectory(0, "snapshots")
 

--- a/src/duplicacy_snapshotmanager_test.go
+++ b/src/duplicacy_snapshotmanager_test.go
@@ -95,14 +95,14 @@ func createTestSnapshotManager(testDir string) *SnapshotManager {
 	os.RemoveAll(testDir)
 	os.MkdirAll(testDir, 0700)
 
-	storage, _ := CreateFileStorage(testDir, 1, false, 1)
+	storage, _ := CreateFileStorage(testDir, 2, false, 1)
 	storage.CreateDirectory(0, "chunks")
 	storage.CreateDirectory(0, "snapshots")
 	config := CreateConfig()
 	snapshotManager := CreateSnapshotManager(config, storage)
 
 	cacheDir := path.Join(testDir, "cache")
-	snapshotCache, _ := CreateFileStorage(cacheDir, 1, false, 1)
+	snapshotCache, _ := CreateFileStorage(cacheDir, 2, false, 1)
 	snapshotCache.CreateDirectory(0, "chunks")
 	snapshotCache.CreateDirectory(0, "snapshots")
 

--- a/src/duplicacy_storage.go
+++ b/src/duplicacy_storage.go
@@ -146,7 +146,7 @@ func CreateStorage(preference Preference, resetPassword bool, threads int) (stor
 	}
 
 	if isFileStorage {
-		fileStorage, err := CreateFileStorage(storageURL, 2, isCacheNeeded, threads)
+		fileStorage, err := CreateFileStorage(storageURL, 1, isCacheNeeded, threads)
 		if err != nil {
 			LOG_ERROR("STORAGE_CREATE", "Failed to load the file storage at %s: %v", storageURL, err)
 			return nil
@@ -164,7 +164,7 @@ func CreateStorage(preference Preference, resetPassword bool, threads int) (stor
 	}
 
 	if strings.HasPrefix(storageURL, "samba://") {
-		fileStorage, err := CreateFileStorage(storageURL[8:], 2, true, threads)
+		fileStorage, err := CreateFileStorage(storageURL[8:], 1, true, threads)
 		if err != nil {
 			LOG_ERROR("STORAGE_CREATE", "Failed to load the file storage at %s: %v", storageURL, err)
 			return nil
@@ -311,7 +311,7 @@ func CreateStorage(preference Preference, resetPassword bool, threads int) (stor
 			return checkHostKey(hostname, remote, key)
 		}
 
-		sftpStorage, err := CreateSFTPStorage(server, port, username, storageDir, authMethods, hostKeyChecker, threads)
+		sftpStorage, err := CreateSFTPStorage(server, port, username, storageDir, 1, authMethods, hostKeyChecker, threads)
 		if err != nil {
 			LOG_ERROR("STORAGE_CREATE", "Failed to load the SFTP storage at %s: %v", storageURL, err)
 			return nil
@@ -373,7 +373,7 @@ func CreateStorage(preference Preference, resetPassword bool, threads int) (stor
 	} else if matched[1] == "dropbox" {
 		storageDir := matched[3] + matched[5]
 		token := GetPassword(preference, "dropbox_token", "Enter Dropbox access token:", true, resetPassword)
-		dropboxStorage, err := CreateDropboxStorage(token, storageDir, threads)
+		dropboxStorage, err := CreateDropboxStorage(token, storageDir, 1, threads)
 		if err != nil {
 			LOG_ERROR("STORAGE_CREATE", "Failed to load the dropbox storage: %v", err)
 			return nil

--- a/src/duplicacy_storage.go
+++ b/src/duplicacy_storage.go
@@ -146,7 +146,7 @@ func CreateStorage(preference Preference, resetPassword bool, threads int) (stor
 	}
 
 	if isFileStorage {
-		fileStorage, err := CreateFileStorage(storageURL, 1, isCacheNeeded, threads)
+		fileStorage, err := CreateFileStorage(storageURL, 2, isCacheNeeded, threads)
 		if err != nil {
 			LOG_ERROR("STORAGE_CREATE", "Failed to load the file storage at %s: %v", storageURL, err)
 			return nil
@@ -164,7 +164,7 @@ func CreateStorage(preference Preference, resetPassword bool, threads int) (stor
 	}
 
 	if strings.HasPrefix(storageURL, "samba://") {
-		fileStorage, err := CreateFileStorage(storageURL[8:], 1, true, threads)
+		fileStorage, err := CreateFileStorage(storageURL[8:], 2, true, threads)
 		if err != nil {
 			LOG_ERROR("STORAGE_CREATE", "Failed to load the file storage at %s: %v", storageURL, err)
 			return nil
@@ -311,7 +311,7 @@ func CreateStorage(preference Preference, resetPassword bool, threads int) (stor
 			return checkHostKey(hostname, remote, key)
 		}
 
-		sftpStorage, err := CreateSFTPStorage(server, port, username, storageDir, 1, authMethods, hostKeyChecker, threads)
+		sftpStorage, err := CreateSFTPStorage(server, port, username, storageDir, 2, authMethods, hostKeyChecker, threads)
 		if err != nil {
 			LOG_ERROR("STORAGE_CREATE", "Failed to load the SFTP storage at %s: %v", storageURL, err)
 			return nil

--- a/src/duplicacy_storage_test.go
+++ b/src/duplicacy_storage_test.go
@@ -41,7 +41,7 @@ func init() {
 func loadStorage(localStoragePath string, threads int) (Storage, error) {
 
 	if testStorageName == "" || testStorageName == "file" {
-		return CreateFileStorage(localStoragePath, 1, false, threads)
+		return CreateFileStorage(localStoragePath, 2, false, threads)
 	}
 
 	config, err := ioutil.ReadFile("test_storage.conf")
@@ -64,10 +64,10 @@ func loadStorage(localStoragePath string, threads int) (Storage, error) {
 	if testStorageName == "flat" {
 		return CreateFileStorage(localStoragePath, 0, false, threads)
 	} else if testStorageName == "samba" {
-		return CreateFileStorage(localStoragePath, 1, true, threads)
+		return CreateFileStorage(localStoragePath, 2, true, threads)
 	} else if testStorageName == "sftp" {
 		port, _ := strconv.Atoi(storage["port"])
-		return CreateSFTPStorageWithPassword(storage["server"], port, storage["username"], storage["directory"], 1, storage["password"], threads)
+		return CreateSFTPStorageWithPassword(storage["server"], port, storage["username"], storage["directory"], 2, storage["password"], threads)
 	} else if testStorageName == "s3" || testStorageName == "wasabi" {
 		return CreateS3Storage(storage["region"], storage["endpoint"], storage["bucket"], storage["directory"], storage["access_key"], storage["secret_key"], threads, true, false)
 	} else if testStorageName == "s3c" {

--- a/src/duplicacy_storage_test.go
+++ b/src/duplicacy_storage_test.go
@@ -41,7 +41,7 @@ func init() {
 func loadStorage(localStoragePath string, threads int) (Storage, error) {
 
 	if testStorageName == "" || testStorageName == "file" {
-		return CreateFileStorage(localStoragePath, 2, false, threads)
+		return CreateFileStorage(localStoragePath, 1, false, threads)
 	}
 
 	config, err := ioutil.ReadFile("test_storage.conf")
@@ -64,10 +64,10 @@ func loadStorage(localStoragePath string, threads int) (Storage, error) {
 	if testStorageName == "flat" {
 		return CreateFileStorage(localStoragePath, 0, false, threads)
 	} else if testStorageName == "samba" {
-		return CreateFileStorage(localStoragePath, 2, true, threads)
+		return CreateFileStorage(localStoragePath, 1, true, threads)
 	} else if testStorageName == "sftp" {
 		port, _ := strconv.Atoi(storage["port"])
-		return CreateSFTPStorageWithPassword(storage["server"], port, storage["username"], storage["directory"], storage["password"], threads)
+		return CreateSFTPStorageWithPassword(storage["server"], port, storage["username"], storage["directory"], 1, storage["password"], threads)
 	} else if testStorageName == "s3" || testStorageName == "wasabi" {
 		return CreateS3Storage(storage["region"], storage["endpoint"], storage["bucket"], storage["directory"], storage["access_key"], storage["secret_key"], threads, true, false)
 	} else if testStorageName == "s3c" {
@@ -77,7 +77,7 @@ func loadStorage(localStoragePath string, threads int) (Storage, error) {
 	} else if testStorageName == "minios" {
 		return CreateS3Storage(storage["region"], storage["endpoint"], storage["bucket"], storage["directory"], storage["access_key"], storage["secret_key"], threads, true, true)
 	} else if testStorageName == "dropbox" {
-		return CreateDropboxStorage(storage["token"], storage["directory"], threads)
+		return CreateDropboxStorage(storage["token"], storage["directory"], 1, threads)
 	} else if testStorageName == "b2" {
 		return CreateB2Storage(storage["account"], storage["key"], storage["bucket"], threads)
 	} else if testStorageName == "gcs-s3" {


### PR DESCRIPTION
As per https://github.com/gilbertchen/duplicacy/issues/163#issuecomment-331242178

> [...] listing (eventually) 65k dirs over SFTP, with a full roundtrip for each one, would just take forever (it's already annoying enough within the LAN).
Single level nesting would result in ~1k files per dir with a 1TB repo with the default chunk size which hardly seems overwhelming - and would cut down dirlist requests to 256, or about 5 minutes, which is far more reasonable.

Quick and informal testing (with a tiny repo) shows that `backup`, `copy`, `prune`, `list` and `check` keep working as expected, i.e. single-nested (new) chunks can coexist alongside preexisting double-nested chunks.