### PR TITLE
Fix security weakness in storage key derivation

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -13,10 +13,11 @@ USAGE:
 
 OPTIONS:
    -encrypt, -e                    encrypt the storage with a password
-   -chunk-size, -c 4M              the average size of chunks
-   -max-chunk-size, -max 16M       the maximum size of chunks (defaults to chunk-size * 4)
-   -min-chunk-size, -min 1M        the minimum size of chunks (defaults to chunk-size / 4)
-   -pref-dir <preference directory path>    Specify alternate location for .duplicacy preferences directory
+   -chunk-size, -c <size>          the average size of chunks (default is 4M)
+   -max-chunk-size, -max <size>    the maximum size of chunks (default is chunk-size*4)
+   -min-chunk-size, -min <size>    the minimum size of chunks (default is chunk-size/4)
+   -iterations <i>				   the number of iterations used in storage key deriviation (default is 16384)
+   -pref-dir <path>                alternate location for the .duplicacy directory (absolute or relative to current directory)
 ```
 
 The *init* command first connects to the storage specified by the storage URL.  If the storage has been already been initialized before, it will download the storage configuration (stored in the file named *config*) and ignore the options provided in the command line.  Otherwise, it will create the configuration file from the options and upload the file.
@@ -31,7 +32,9 @@ The `-e` option controls whether or not encryption will be enabled for the stora
 
 The three chunk size parameters are passed to the variable-size chunking algorithm.  Their values are important to the overall performance, especially for cloud storages.  If the chunk size is too small, a lot of overhead will be in sending requests and receiving responses.  If the chunk size is too large, the effect of de-duplication will be less obvious as more data will need to be transferred with each chunk.
 
-The `-pref-dir` controls the location of the preferences directory. If not specified, a directory named .duplicacy is created in the repository. If specified, it must point to a non-existing directory. The directory is created and a .duplicacy file is created in the repository. The .duplicacy file contains the absolute path name to the preferences directory.
+The `-iterations` option speicifies how many iterations are used to generate the key that encrypts the `config` file from the storage password.
+
+The `-pref-dir` option controls the location of the preferences directory. If not specified, a directory named .duplicacy is created in the repository. If specified, it must point to a non-existing directory. The directory is created and a .duplicacy file is created in the repository. The .duplicacy file contains the absolute path name to the preferences directory.
 
 Once a storage has been initialized with these parameters, these parameters cannot be modified any more.
 
@@ -314,11 +317,14 @@ USAGE:
 
 OPTIONS:
    -storage <storage name>  change the password used to access the specified storage
+   -iterations <i>          the number of iterations used in storage key deriviation (default is 16384)
 ```
 
 The *password* command decrypts the storage configuration file *config* using the old password, and re-encrypts the file
 using a new password.  It does not change all the encryption keys used to encrypt and decrypt chunk files,
 snapshot files, etc.
+
+The `-iterations` option speicifies how many iterations are used to generate the key that encrypts the `config` file from the storage password.
 
 You can specify the storage to change the password for when working with multiple storages.
 
@@ -332,17 +338,19 @@ USAGE:
    duplicacy add [command options] <storage name> <snapshot id> <storage url>
 
 OPTIONS:
-   -encrypt, -e                    Encrypt the storage with a password
-   -chunk-size, -c 4M              the average size of chunks
-   -max-chunk-size, -max 16M       the maximum size of chunks (defaults to chunk-size * 4)
-   -min-chunk-size, -min 1M        the minimum size of chunks (defaults to chunk-size / 4)
-   -compression-level, -l <level>  compression level (defaults to -1)
+   -encrypt, -e                    encrypt the storage with a password
+   -chunk-size, -c <size> 		   the average size of chunks (defaults to 4M)
+   -max-chunk-size, -max <size>    the maximum size of chunks (defaults to chunk-size*4)
+   -min-chunk-size, -min <size>    the minimum size of chunks (defaults to chunk-size/4)
+   -iterations <i>                 the number of iterations used in storage key deriviation (default is 16384)
    -copy <storage name>            make the new storage copy-compatible with an existing one
 ```
 
 The *add* command connects another storage to the current repository.  Like the *init* command, if the storage has not been initialized before, a storage configuration file derived from the command line options will be uploaded, but those options will be ignored if the configuration file already exists in the storage.
 
 A unique storage name must be given in order to distinguish it from other storages.
+
+The `-iterations` option speicifies how many iterations are used to generate the key that encrypts the `config` file from the storage password.
 
 The `-copy` option is required if later you want to copy snapshots between this storage and another storage. Two storages are copy-compatible if they have the same average chunk size, the same maximum chunk size, the same minimum chunk size, the same chunk seed (used in calculating the rolling hash in the variable-size chunks algorithm), and the same hash key.  If the `-copy` option is specified, these parameters will be copied from the existing storage rather than from the command line.
 

--- a/duplicacy/duplicacy_main.go
+++ b/duplicacy/duplicacy_main.go
@@ -396,7 +396,11 @@ func configRepository(context *cli.Context, init bool) {
 			}
 		}
 
-		duplicacy.ConfigStorage(storage, compressionLevel, averageChunkSize, maximumChunkSize,
+		iterations := context.Int("iterations")
+		if iterations == 0 {
+			iterations = duplicacy.CONFIG_DEFAULT_ITERATIONS
+		}
+		duplicacy.ConfigStorage(storage, iterations, compressionLevel, averageChunkSize, maximumChunkSize,
 			minimumChunkSize, storagePassword, otherConfig)
 	}
 
@@ -576,7 +580,12 @@ func changePassword(context *cli.Context) {
 		return
 	}
 
-	duplicacy.UploadConfig(storage, config, newPassword)
+	iterations := context.Int("iterations")
+	if iterations == 0 {
+		iterations = duplicacy.CONFIG_DEFAULT_ITERATIONS
+	}
+
+	duplicacy.UploadConfig(storage, config, newPassword, iterations)
 
 	duplicacy.SavePassword(*preference, "password", newPassword)
 
@@ -1174,23 +1183,28 @@ func main() {
 				cli.StringFlag{
 					Name:     "chunk-size, c",
 					Value:    "4M",
-					Usage:    "the average size of chunks",
-					Argument: "4M",
+					Usage:    "the average size of chunks (defaults to 4M)",
+					Argument: "<size>",
 				},
 				cli.StringFlag{
 					Name:     "max-chunk-size, max",
-					Usage:    "the maximum size of chunks (defaults to chunk-size * 4)",
-					Argument: "16M",
+					Usage:    "the maximum size of chunks (defaults to chunk-size*4)",
+					Argument: "<size>",
 				},
 				cli.StringFlag{
 					Name:     "min-chunk-size, min",
-					Usage:    "the minimum size of chunks (defaults to chunk-size / 4)",
-					Argument: "1M",
+					Usage:    "the minimum size of chunks (defaults to chunk-size/4)",
+					Argument: "<size>",
+				},
+				cli.IntFlag{
+					Name:     "iterations",
+					Usage:    "the number of iterations used in storage key deriviation (default is 16384)",
+					Argument: "<i>",
 				},
 				cli.StringFlag{
 					Name:     "pref-dir",
-					Usage:    "Specify alternate location for .duplicacy preferences directory (absolute or relative to current directory)",
-					Argument: "<preferences directory path>",
+					Usage:    "alternate location for the .duplicacy directory (absolute or relative to current directory)",
+					Argument: "<path>",
 				},
 			},
 			Usage:     "Initialize the storage if necessary and the current directory as the repository",
@@ -1538,6 +1552,11 @@ func main() {
 					Usage:    "change the password used to access the specified storage",
 					Argument: "<storage name>",
 				},
+				cli.IntFlag{
+					Name:     "iterations",
+					Usage:    "the number of iterations used in storage key deriviation (default is 16384)",
+					Argument: "<i>",
+				},
 			},
 			Usage:     "Change the storage password",
 			ArgsUsage: " ",
@@ -1549,23 +1568,28 @@ func main() {
 			Flags: []cli.Flag{
 				cli.BoolFlag{
 					Name:  "encrypt, e",
-					Usage: "Encrypt the storage with a password",
+					Usage: "encrypt the storage with a password",
 				},
 				cli.StringFlag{
 					Name:     "chunk-size, c",
 					Value:    "4M",
-					Usage:    "the average size of chunks",
-					Argument: "4M",
+					Usage:    "the average size of chunks (default is 4M)",
+					Argument: "<size>",
 				},
 				cli.StringFlag{
 					Name:     "max-chunk-size, max",
-					Usage:    "the maximum size of chunks (defaults to chunk-size * 4)",
-					Argument: "16M",
+					Usage:    "the maximum size of chunks (default is chunk-size*4)",
+					Argument: "<size>",
 				},
 				cli.StringFlag{
 					Name:     "min-chunk-size, min",
-					Usage:    "the minimum size of chunks (defaults to chunk-size / 4)",
-					Argument: "1M",
+					Usage:    "the minimum size of chunks (default is chunk-size/4)",
+					Argument: "<size>",
+				},
+				cli.IntFlag{
+					Name:     "iterations",
+					Usage:    "the number of iterations used in storage key deriviation (default is 16384)",
+					Argument: "<i>",
 				},
 				cli.StringFlag{
 					Name:     "copy",

--- a/src/duplicacy_backupmanager_test.go
+++ b/src/duplicacy_backupmanager_test.go
@@ -227,11 +227,11 @@ func TestBackupManager(t *testing.T) {
 
 	time.Sleep(time.Duration(delay) * time.Second)
 	if testFixedChunkSize {
-		if !ConfigStorage(storage, 100, 64*1024, 64*1024, 64*1024, password, nil) {
+		if !ConfigStorage(storage, 16384, 100, 64*1024, 64*1024, 64*1024, password, nil) {
 			t.Errorf("Failed to initialize the storage")
 		}
 	} else {
-		if !ConfigStorage(storage, 100, 64*1024, 256*1024, 16*1024, password, nil) {
+		if !ConfigStorage(storage, 16384, 100, 64*1024, 256*1024, 16*1024, password, nil) {
 			t.Errorf("Failed to initialize the storage")
 		}
 	}

--- a/src/duplicacy_utils.go
+++ b/src/duplicacy_utils.go
@@ -159,8 +159,8 @@ func RateLimitedCopy(writer io.Writer, reader io.Reader, rate int) (written int6
 }
 
 // GenerateKeyFromPassword generates a key from the password.
-func GenerateKeyFromPassword(password string, salt []byte, iteartions int) []byte {
-	return pbkdf2.Key([]byte(password), salt, iteartions, 32, sha256.New)
+func GenerateKeyFromPassword(password string, salt []byte, iterations int) []byte {
+	return pbkdf2.Key([]byte(password), salt, iterations, 32, sha256.New)
 }
 
 // Get password from preference, env, but don't start any keyring request

--- a/src/duplicacy_utils.go
+++ b/src/duplicacy_utils.go
@@ -159,8 +159,8 @@ func RateLimitedCopy(writer io.Writer, reader io.Reader, rate int) (written int6
 }
 
 // GenerateKeyFromPassword generates a key from the password.
-func GenerateKeyFromPassword(password string) []byte {
-	return pbkdf2.Key([]byte(password), DEFAULT_KEY, 16384, 32, sha256.New)
+func GenerateKeyFromPassword(password string, salt []byte, iteartions int) []byte {
+	return pbkdf2.Key([]byte(password), salt, iteartions, 32, sha256.New)
 }
 
 // Get password from preference, env, but don't start any keyring request


### PR DESCRIPTION
As suggested in #137, the key to encrypt the `config` file should be generated using a random salt and a configurable number of iterations.  This PR implements the required changes.

The new format for the `config` file is "duplicacy\001" + salt + #iterations + encrypted content, while the old format is "duplicacy\000" + encrypted content.

A `config` file in the old format can still be opened.  The `password` command can be used to convert to the new format (in addition to changing the password).