### PR TITLE
 allow skip setting uid/gid on restored files

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -87,17 +87,20 @@ OPTIONS:
    -hash                    detect file differences by hash (rather than size and timestamp)
    -overwrite               overwrite existing files in the repository
    -delete                  delete files not in the snapshot
+   -ignore-owner            do not set the original uid/gid on restored files
    -stats                   show statistics during and after restore
    -threads <n>             number of downloading threads
    -limit-rate <kB/s>       the maximum download rate (in kilobytes/sec)
    -storage <storage name>  restore from the specified storage instead of the default one
 ```
 
-The *restore* command restores the repository to a previous revision.  By default the restore procedure will treat files that have the same sizes and timestamps as those in the snapshot as unchanged files, but with the -hash option, every file will be fully scanned to make sure they are in fact unchanged.
+The *restore* command restores the repository to a previous revision.  By default the restore procedure will treat files that have the same sizes and timestamps as those in the snapshot as unchanged files, but with the `-hash` option, every file will be fully scanned to make sure they are in fact unchanged.
 
 By default the restore procedure will not overwriting existing files, unless the `-overwrite` option is specified.
 
 The `-delete` option indicates that files not in the snapshot will be removed.
+
+If the `-ignore-owner` option is specified, the restore procedure will not attempt to restore the original user/group id ownership on restored files (all restored files will be owned by the current user); this can be useful when restoring to a new or different machine.
 
 If the `-stats` option is specified, statistical information such as transfer speed, and number of chunks will be displayed throughout the restore procedure.
 

--- a/duplicacy/duplicacy_main.go
+++ b/duplicacy/duplicacy_main.go
@@ -691,6 +691,8 @@ func restoreRepository(context *cli.Context) {
 	quickMode := !context.Bool("hash")
 	overwrite := context.Bool("overwrite")
 	deleteMode := context.Bool("delete")
+	setOwner := !context.Bool("ignore-owner")
+
 	showStatistics := context.Bool("stats")
 
 	var patterns []string
@@ -732,7 +734,7 @@ func restoreRepository(context *cli.Context) {
 	duplicacy.SavePassword(*preference, "password", password)
 
 	backupManager.SetupSnapshotCache(preference.Name)
-	backupManager.Restore(repository, revision, true, quickMode, threads, overwrite, deleteMode, showStatistics, patterns)
+	backupManager.Restore(repository, revision, true, quickMode, threads, overwrite, deleteMode, setOwner, showStatistics, patterns)
 
 	runScript(context, preference.Name, "post")
 }
@@ -1278,6 +1280,10 @@ func main() {
 				cli.BoolFlag{
 					Name:  "delete",
 					Usage: "delete files not in the snapshot",
+				},
+				cli.BoolFlag{
+					Name:  "ignore-owner",
+					Usage: "do not set the original uid/gid on restored files",
 				},
 				cli.BoolFlag{
 					Name:  "stats",

--- a/src/duplicacy_entry.go
+++ b/src/duplicacy_entry.go
@@ -286,7 +286,7 @@ func (entry *Entry) String(maxSizeDigits int) string {
 	return fmt.Sprintf("%*d %s %64s %s", maxSizeDigits, entry.Size, modifiedTime, entry.Hash, entry.Path)
 }
 
-func (entry *Entry) RestoreMetadata(fullPath string, fileInfo *os.FileInfo) bool {
+func (entry *Entry) RestoreMetadata(fullPath string, fileInfo *os.FileInfo, setOwner bool) bool {
 
 	if fileInfo == nil {
 		stat, err := os.Stat(fullPath)
@@ -318,7 +318,11 @@ func (entry *Entry) RestoreMetadata(fullPath string, fileInfo *os.FileInfo) bool
 		entry.SetAttributesToFile(fullPath)
 	}
 
-	return SetOwner(fullPath, entry, fileInfo)
+	if setOwner {
+		return SetOwner(fullPath, entry, fileInfo)
+	} else {
+		return true
+	}
 }
 
 // Return -1 if 'left' should appear before 'right', 1 if opposite, and 0 if they are the same.


### PR DESCRIPTION
> If the `-ignore-owner` option is specified, the restore procedure will not attempt to restore the original user/group id ownership on restored files (all restored files will be owned by the current user); this can be useful when restoring to a new or different machine.

Guidance needed about https://github.com/gilbertchen/duplicacy/compare/master...lowne:restore-ignore-uid?expand=1#diff-8542592c8489202c10c8a767962adc17L881 - unsure why that line is there.
