### PR TITLE
Implement new chunk directory structure

### DIFF
--- a/src/duplicacy_acdclient.go
+++ b/src/duplicacy_acdclient.go
@@ -69,7 +69,7 @@ func NewACDClient(tokenFile string) (*ACDClient, error) {
 
 func (client *ACDClient) call(url string, method string, input interface{}, contentType string) (io.ReadCloser, int64, error) {
 
-	LOG_DEBUG("ACD_CALL", "Calling %s", url)
+	//LOG_DEBUG("ACD_CALL", "%s %s", method, url)
 
 	var response *http.Response
 
@@ -256,7 +256,7 @@ type ACDListEntriesOutput struct {
 	Entries   []ACDEntry `json:"data"`
 }
 
-func (client *ACDClient) ListEntries(parentID string, listFiles bool) ([]ACDEntry, error) {
+func (client *ACDClient) ListEntries(parentID string, listFiles bool, listDirectories bool) ([]ACDEntry, error) {
 
 	startToken := ""
 
@@ -264,20 +264,22 @@ func (client *ACDClient) ListEntries(parentID string, listFiles bool) ([]ACDEntr
 
 	for {
 
-		url := client.MetadataURL + "nodes/" + parentID + "/children?filters="
+		url := client.MetadataURL + "nodes/" + parentID + "/children?"
 
-		if listFiles {
-			url += "kind:FILE"
-		} else {
-			url += "kind:FOLDER"
+		if listFiles && !listDirectories {
+			url += "filters=kind:FILE&"
+		} else if !listFiles && listDirectories {
+			url += "filters=kind:FOLDER&"
 		}
 
 		if startToken != "" {
-			url += "&startToken=" + startToken
+			url += "startToken=" + startToken + "&"
 		}
 
 		if client.TestMode {
-			url += "&limit=8"
+			url += "limit=8"
+		} else {
+			url += "limit=200"
 		}
 
 		readCloser, _, err := client.call(url, "GET", 0, "")

--- a/src/duplicacy_acdclient_test.go
+++ b/src/duplicacy_acdclient_test.go
@@ -103,7 +103,7 @@ func TestACDClient(t *testing.T) {
 		}
 	}
 
-	entries, err := acdClient.ListEntries(test1ID, true)
+	entries, err := acdClient.ListEntries(test1ID, true, false)
 	if err != nil {
 		t.Errorf("Error list randomly generated files: %v", err)
 		return
@@ -117,7 +117,7 @@ func TestACDClient(t *testing.T) {
 		}
 	}
 
-	entries, err = acdClient.ListEntries(test2ID, true)
+	entries, err = acdClient.ListEntries(test2ID, true, false)
 	if err != nil {
 		t.Errorf("Error list randomly generated files: %v", err)
 		return

--- a/src/duplicacy_azurestorage.go
+++ b/src/duplicacy_azurestorage.go
@@ -12,7 +12,7 @@ import (
 )
 
 type AzureStorage struct {
-	RateLimitedStorage
+	StorageBase
 
 	containers []*storage.Container
 }
@@ -47,6 +47,8 @@ func CreateAzureStorage(accountName string, accountKey string,
 		containers: containers,
 	}
 
+	azureStorage.DerivedStorage = azureStorage
+	azureStorage.SetDefaultNestingLevels([]int{0}, 0)
 	return
 }
 
@@ -147,23 +149,6 @@ func (storage *AzureStorage) GetFileInfo(threadIndex int, filePath string) (exis
 	}
 
 	return true, false, blob.Properties.ContentLength, nil
-}
-
-// FindChunk finds the chunk with the specified id.  If 'isFossil' is true, it will search for chunk files with
-// the suffix '.fsl'.
-func (storage *AzureStorage) FindChunk(threadIndex int, chunkID string, isFossil bool) (filePath string, exist bool, size int64, err error) {
-	filePath = "chunks/" + chunkID
-	if isFossil {
-		filePath += ".fsl"
-	}
-
-	exist, _, size, err = storage.GetFileInfo(threadIndex, filePath)
-
-	if err != nil {
-		return "", false, 0, err
-	} else {
-		return filePath, exist, size, err
-	}
 }
 
 // DownloadFile reads the file at 'filePath' into the chunk.

--- a/src/duplicacy_b2storage.go
+++ b/src/duplicacy_b2storage.go
@@ -9,7 +9,7 @@ import (
 )
 
 type B2Storage struct {
-	RateLimitedStorage
+	StorageBase
 
 	clients []*B2Client
 }
@@ -38,6 +38,9 @@ func CreateB2Storage(accountID string, applicationKey string, bucket string, thr
 	storage = &B2Storage{
 		clients: clients,
 	}
+
+	storage.DerivedStorage = storage
+	storage.SetDefaultNestingLevels([]int{0}, 0)
 	return storage, nil
 }
 
@@ -202,17 +205,6 @@ func (storage *B2Storage) GetFileInfo(threadIndex int, filePath string) (exist b
 		}
 	}
 	return true, false, entries[0].Size, nil
-}
-
-// FindChunk finds the chunk with the specified id.  If 'isFossil' is true, it will search for chunk files with
-// the suffix '.fsl'.
-func (storage *B2Storage) FindChunk(threadIndex int, chunkID string, isFossil bool) (filePath string, exist bool, size int64, err error) {
-	filePath = "chunks/" + chunkID
-	if isFossil {
-		filePath += ".fsl"
-	}
-	exist, _, size, err = storage.GetFileInfo(threadIndex, filePath)
-	return filePath, exist, size, err
 }
 
 // DownloadFile reads the file at 'filePath' into the chunk.

--- a/src/duplicacy_backupmanager.go
+++ b/src/duplicacy_backupmanager.go
@@ -79,7 +79,7 @@ func (manager *BackupManager) SetupSnapshotCache(storageName string) bool {
 	preferencePath := GetDuplicacyPreferencePath()
 	cacheDir := path.Join(preferencePath, "cache", storageName)
 
-	storage, err := CreateFileStorage(cacheDir, 2, false, 1)
+	storage, err := CreateFileStorage(cacheDir, false, 1)
 	if err != nil {
 		LOG_ERROR("BACKUP_CACHE", "Failed to create the snapshot cache dir: %v", err)
 		return false
@@ -93,6 +93,7 @@ func (manager *BackupManager) SetupSnapshotCache(storageName string) bool {
 		}
 	}
 
+	storage.SetDefaultNestingLevels([]int{1}, 1)
 	manager.snapshotCache = storage
 	manager.SnapshotManager.snapshotCache = storage
 	return true

--- a/src/duplicacy_backupmanager_test.go
+++ b/src/duplicacy_backupmanager_test.go
@@ -336,6 +336,30 @@ func TestBackupManager(t *testing.T) {
 		}
 	}
 
+	numberOfSnapshots := backupManager.SnapshotManager.ListSnapshots( /*snapshotID*/ "host1" /*revisionsToList*/, nil /*tag*/, "" /*showFiles*/, false /*showChunks*/, false)
+	if numberOfSnapshots != 3 {
+		t.Errorf("Expected 3 snapshots but got %d", numberOfSnapshots)
+	}
+	backupManager.SnapshotManager.CheckSnapshots( /*snapshotID*/ "host1" /*revisions*/, []int{1, 2, 3} /*tag*/, "",
+		/*showStatistics*/ false /*showTabular*/, false /*checkFiles*/, false /*searchFossils*/, false /*resurrect*/, false)
+	backupManager.SnapshotManager.PruneSnapshots("host1", "host1" /*revisions*/, []int{1} /*tags*/, nil /*retentions*/, nil,
+		/*exhaustive*/ false /*exclusive=*/, false /*ignoredIDs*/, nil /*dryRun*/, false /*deleteOnly*/, false /*collectOnly*/, false)
+	numberOfSnapshots = backupManager.SnapshotManager.ListSnapshots( /*snapshotID*/ "host1" /*revisionsToList*/, nil /*tag*/, "" /*showFiles*/, false /*showChunks*/, false)
+	if numberOfSnapshots != 2 {
+		t.Errorf("Expected 2 snapshots but got %d", numberOfSnapshots)
+	}
+	backupManager.SnapshotManager.CheckSnapshots( /*snapshotID*/ "host1" /*revisions*/, []int{2, 3} /*tag*/, "",
+		/*showStatistics*/ false /*showTabular*/, false /*checkFiles*/, false /*searchFossils*/, false /*resurrect*/, false)
+	backupManager.Backup(testDir+"/repository1" /*quickMode=*/, false, threads, "fourth", false, false)
+	backupManager.SnapshotManager.PruneSnapshots("host1", "host1" /*revisions*/, nil /*tags*/, nil /*retentions*/, nil,
+		/*exhaustive*/ false /*exclusive=*/, true /*ignoredIDs*/, nil /*dryRun*/, false /*deleteOnly*/, false /*collectOnly*/, false)
+	numberOfSnapshots = backupManager.SnapshotManager.ListSnapshots( /*snapshotID*/ "host1" /*revisionsToList*/, nil /*tag*/, "" /*showFiles*/, false /*showChunks*/, false)
+	if numberOfSnapshots != 3 {
+		t.Errorf("Expected 3 snapshots but got %d", numberOfSnapshots)
+	}
+	backupManager.SnapshotManager.CheckSnapshots( /*snapshotID*/ "host1" /*revisions*/, []int{2, 3, 4} /*tag*/, "",
+		/*showStatistics*/ false /*showTabular*/, false /*checkFiles*/, false /*searchFossils*/, false /*resurrect*/, false)
+
 	/*buf := make([]byte, 1<<16)
 	  runtime.Stack(buf, true)
 	  fmt.Printf("%s", buf)*/

--- a/src/duplicacy_chunkdownloader.go
+++ b/src/duplicacy_chunkdownloader.go
@@ -326,7 +326,7 @@ func (downloader *ChunkDownloader) Download(threadIndex int, task ChunkDownloadT
 	}
 
 	const MaxDownloadAttempts = 3
-	for downloadAttempt := 0;; downloadAttempt++ {
+	for downloadAttempt := 0; ; downloadAttempt++ {
 		err = downloader.storage.DownloadFile(threadIndex, chunkPath, chunk)
 		if err != nil {
 			if err == io.ErrUnexpectedEOF && downloadAttempt < MaxDownloadAttempts {

--- a/src/duplicacy_config.go
+++ b/src/duplicacy_config.go
@@ -46,6 +46,8 @@ type Config struct {
 
 	ChunkSeed []byte `json:"chunk-seed"`
 
+	FixedNesting bool `json:"fixed-nesting"`
+
 	// Use HMAC-SHA256(hashKey, plaintext) as the chunk hash.
 	// Use HMAC-SHA256(idKey, chunk hash) as the file name of the chunk
 	// For chunks, use HMAC-SHA256(chunkKey, chunk hash) as the encryption key
@@ -63,7 +65,7 @@ type Config struct {
 	// for encrypting a non-chunk file
 	FileKey []byte `json:"-"`
 
-	chunkPool      chan *Chunk `json:"-"`
+	chunkPool      chan *Chunk
 	numberOfChunks int32
 	dryRun         bool
 }
@@ -148,6 +150,7 @@ func CreateConfigFromParameters(compressionLevel int, averageChunkSize int, maxi
 		AverageChunkSize: averageChunkSize,
 		MaximumChunkSize: maximumChunkSize,
 		MinimumChunkSize: mininumChunkSize,
+		FixedNesting:     true,
 	}
 
 	if isEncrypted {
@@ -379,6 +382,8 @@ func DownloadConfig(storage Storage, password string) (config *Config, isEncrypt
 	if err != nil {
 		return nil, false, fmt.Errorf("Failed to parse the config file: %v", err)
 	}
+
+	storage.SetNestingLevels(config)
 
 	return config, false, nil
 

--- a/src/duplicacy_gcsstorage.go
+++ b/src/duplicacy_gcsstorage.go
@@ -24,7 +24,7 @@ import (
 )
 
 type GCSStorage struct {
-	RateLimitedStorage
+	StorageBase
 
 	bucket     *gcs.BucketHandle
 	storageDir string
@@ -101,8 +101,9 @@ func CreateGCSStorage(tokenFile string, bucketName string, storageDir string, th
 		numberOfThreads: threads,
 	}
 
+	storage.DerivedStorage = storage
+	storage.SetDefaultNestingLevels([]int{0}, 0)
 	return storage, nil
-
 }
 
 func (storage *GCSStorage) shouldRetry(backoff *int, err error) (bool, error) {
@@ -236,19 +237,6 @@ func (storage *GCSStorage) GetFileInfo(threadIndex int, filePath string) (exist 
 	}
 
 	return true, false, attributes.Size, nil
-}
-
-// FindChunk finds the chunk with the specified id.  If 'isFossil' is true, it will search for chunk files with
-// the suffix '.fsl'.
-func (storage *GCSStorage) FindChunk(threadIndex int, chunkID string, isFossil bool) (filePath string, exist bool, size int64, err error) {
-	filePath = "chunks/" + chunkID
-	if isFossil {
-		filePath += ".fsl"
-	}
-
-	exist, _, size, err = storage.GetFileInfo(threadIndex, filePath)
-
-	return filePath, exist, size, err
 }
 
 // DownloadFile reads the file at 'filePath' into the chunk.

--- a/src/duplicacy_hubicstorage.go
+++ b/src/duplicacy_hubicstorage.go
@@ -10,7 +10,7 @@ import (
 )
 
 type HubicStorage struct {
-	RateLimitedStorage
+	StorageBase
 
 	client          *HubicClient
 	storageDir      string
@@ -64,8 +64,9 @@ func CreateHubicStorage(tokenFile string, storagePath string, threads int) (stor
 		}
 	}
 
+	storage.DerivedStorage = storage
+	storage.SetDefaultNestingLevels([]int{0}, 0)
 	return storage, nil
-
 }
 
 // ListFiles return the list of files and subdirectories under 'dir' (non-recursively)
@@ -156,18 +157,6 @@ func (storage *HubicStorage) GetFileInfo(threadIndex int, filePath string) (exis
 		filePath = filePath[:len(filePath)-1]
 	}
 	return storage.client.GetFileInfo(storage.storageDir + "/" + filePath)
-}
-
-// FindChunk finds the chunk with the specified id.  If 'isFossil' is true, it will search for chunk files with
-// the suffix '.fsl'.
-func (storage *HubicStorage) FindChunk(threadIndex int, chunkID string, isFossil bool) (filePath string, exist bool, size int64, err error) {
-	filePath = "chunks/" + chunkID
-	if isFossil {
-		filePath += ".fsl"
-	}
-
-	exist, _, size, err = storage.client.GetFileInfo(storage.storageDir + "/" + filePath)
-	return filePath, exist, size, err
 }
 
 // DownloadFile reads the file at 'filePath' into the chunk.

--- a/src/duplicacy_s3cstorage.go
+++ b/src/duplicacy_s3cstorage.go
@@ -13,7 +13,7 @@ import (
 
 // S3CStorage is a storage backend for s3 compatible storages that require V2 Signing.
 type S3CStorage struct {
-	RateLimitedStorage
+	StorageBase
 
 	buckets    []*s3.Bucket
 	storageDir string
@@ -58,6 +58,8 @@ func CreateS3CStorage(regionName string, endpoint string, bucketName string, sto
 		storageDir: storageDir,
 	}
 
+	storage.DerivedStorage = storage
+	storage.SetDefaultNestingLevels([]int{0}, 0)
 	return storage, nil
 }
 
@@ -152,25 +154,6 @@ func (storage *S3CStorage) GetFileInfo(threadIndex int, filePath string) (exist 
 	} else {
 		return true, false, response.ContentLength, nil
 	}
-}
-
-// FindChunk finds the chunk with the specified id.  If 'isFossil' is true, it will search for chunk files with
-// the suffix '.fsl'.
-func (storage *S3CStorage) FindChunk(threadIndex int, chunkID string, isFossil bool) (filePath string, exist bool, size int64, err error) {
-
-	filePath = "chunks/" + chunkID
-	if isFossil {
-		filePath += ".fsl"
-	}
-
-	exist, _, size, err = storage.GetFileInfo(threadIndex, filePath)
-
-	if err != nil {
-		return "", false, 0, err
-	} else {
-		return filePath, exist, size, err
-	}
-
 }
 
 // DownloadFile reads the file at 'filePath' into the chunk.

--- a/src/duplicacy_snapshotmanager.go
+++ b/src/duplicacy_snapshotmanager.go
@@ -592,24 +592,6 @@ func (manager *SnapshotManager) ListAllFiles(storage Storage, top string) (allFi
 				allSizes = append(allSizes, sizes[i])
 			}
 		}
-
-		if !manager.config.dryRun {
-			if top == "chunks/" {
-				// We're listing all chunks so this is the perfect place to detect if a directory contains too many
-				// chunks. Create sub-directories if necessary
-				if len(files) > 1024 && !storage.IsFastListing() {
-					for i := 0; i < 256; i++ {
-						subdir := dir + fmt.Sprintf("%02x\n", i)
-						manager.storage.CreateDirectory(0, subdir)
-					}
-				}
-			} else {
-				// Remove chunk sub-directories that are empty
-				if len(files) == 0 && strings.HasPrefix(dir, "chunks/") && dir != "chunks/" {
-					storage.DeleteFile(0, dir)
-				}
-			}
-		}
 	}
 
 	return allFiles, allSizes

--- a/src/duplicacy_snapshotmanager_test.go
+++ b/src/duplicacy_snapshotmanager_test.go
@@ -95,14 +95,14 @@ func createTestSnapshotManager(testDir string) *SnapshotManager {
 	os.RemoveAll(testDir)
 	os.MkdirAll(testDir, 0700)
 
-	storage, _ := CreateFileStorage(testDir, 2, false, 1)
+	storage, _ := CreateFileStorage(testDir, false, 1)
 	storage.CreateDirectory(0, "chunks")
 	storage.CreateDirectory(0, "snapshots")
 	config := CreateConfig()
 	snapshotManager := CreateSnapshotManager(config, storage)
 
 	cacheDir := path.Join(testDir, "cache")
-	snapshotCache, _ := CreateFileStorage(cacheDir, 2, false, 1)
+	snapshotCache, _ := CreateFileStorage(cacheDir, false, 1)
 	snapshotCache.CreateDirectory(0, "chunks")
 	snapshotCache.CreateDirectory(0, "snapshots")
 


### PR DESCRIPTION
This PR implements the new chunk directory structure proposed in #222:

* For storages initialized by earlier versions, there are no changes.
* New storages initialized now will have a key `fixed-nesting` set to `true` in the `config` file.
* This key forces all chunks, regardless of the storage type, to be saved with a nesting level of 1, so a chunk with an id `abcdef...` will be saved as `chunks\ab\cdef...`.
* The nesting level can be adjusted by adding a json file named `nesting` to the storage next to the `config` file, which should include two keys: `read-levels` and `write-level`
* The value of read-levels is an array of integers representing which levels the chunks should be read from. For example, `"read-levels": [0, 1, 2]` means chunks must be searched at level 0, level 1, and level 2, in that order
* The value of write-level is an integer representing the level that chunks should be written to. For example `"write-level": 1` means new chunks will be written to level 1.