### PR TITLE
allow bit-identical `add -copy`

### DIFF
--- a/duplicacy/duplicacy_main.go
+++ b/duplicacy/duplicacy_main.go
@@ -367,6 +367,7 @@ func configRepository(context *cli.Context, init bool) {
 		}
 
 		var otherConfig *duplicacy.Config
+		var bitCopy bool
 		if context.String("copy") != "" {
 
 			otherPreference := duplicacy.FindPreference(context.String("copy"))
@@ -395,6 +396,8 @@ func configRepository(context *cli.Context, init bool) {
 				duplicacy.LOG_ERROR("STORAGE_NOT_CONFIGURED",
 					"The storage to copy the configuration from has not been initialized")
 			}
+
+			bitCopy = context.Bool("bit")
 		}
 
 		iterations := context.Int("iterations")
@@ -402,7 +405,7 @@ func configRepository(context *cli.Context, init bool) {
 			iterations = duplicacy.CONFIG_DEFAULT_ITERATIONS
 		}
 		duplicacy.ConfigStorage(storage, iterations, compressionLevel, averageChunkSize, maximumChunkSize,
-			minimumChunkSize, storagePassword, otherConfig)
+			minimumChunkSize, storagePassword, otherConfig, bitCopy)
 	}
 
 	duplicacy.Preferences = append(duplicacy.Preferences, preference)
@@ -1602,6 +1605,10 @@ func main() {
 					Name:     "copy",
 					Usage:    "make the new storage compatible with an existing one to allow for copy operations",
 					Argument: "<storage name>",
+				},
+				cli.BoolFlag{
+					Name:     "bit",
+					Usage:    "(when using -copy) make the new storage bit-identical to also allow rsync etc.",
 				},
 			},
 			Usage:     "Add an additional storage to be used for the existing repository",

--- a/src/duplicacy_config.go
+++ b/src/duplicacy_config.go
@@ -143,7 +143,7 @@ func (config *Config) Print() {
 }
 
 func CreateConfigFromParameters(compressionLevel int, averageChunkSize int, maximumChunkSize int, mininumChunkSize int,
-	isEncrypted bool, copyFrom *Config) (config *Config) {
+	isEncrypted bool, copyFrom *Config, bitCopy bool) (config *Config) {
 
 	config = &Config{
 		CompressionLevel: compressionLevel,
@@ -182,6 +182,12 @@ func CreateConfigFromParameters(compressionLevel int, averageChunkSize int, maxi
 
 		config.ChunkSeed = copyFrom.ChunkSeed
 		config.HashKey = copyFrom.HashKey
+
+		if bitCopy {
+			config.IDKey = copyFrom.IDKey
+			config.ChunkKey = copyFrom.ChunkKey
+			config.FileKey = copyFrom.FileKey
+		}
 	}
 
 	config.chunkPool = make(chan *Chunk, runtime.NumCPU()*16)
@@ -471,7 +477,7 @@ func UploadConfig(storage Storage, config *Config, password string, iterations i
 // it simply creates a file named 'config' that stores various parameters as well as a set of keys if encryption
 // is enabled.
 func ConfigStorage(storage Storage, iterations int, compressionLevel int, averageChunkSize int, maximumChunkSize int,
-	minimumChunkSize int, password string, copyFrom *Config) bool {
+	minimumChunkSize int, password string, copyFrom *Config, bitCopy bool) bool {
 
 	exist, _, _, err := storage.GetFileInfo(0, "config")
 	if err != nil {
@@ -485,7 +491,7 @@ func ConfigStorage(storage Storage, iterations int, compressionLevel int, averag
 	}
 
 	config := CreateConfigFromParameters(compressionLevel, averageChunkSize, maximumChunkSize, minimumChunkSize, len(password) > 0,
-		copyFrom)
+		copyFrom, bitCopy)
 	if config == nil {
 		return false
 	}


### PR DESCRIPTION
Allows creating `rsync`/`rclone`-compatible redundant storages. (see #163)