### PR TITLE
Skip making a new revision if there is nothing to backup.  Useful for…

### DIFF
--- a/duplicacy/duplicacy_main.go
+++ b/duplicacy/duplicacy_main.go
@@ -502,6 +502,11 @@ func setPreference(context *cli.Context) {
 		newPreference.DoNotSavePassword = triBool.IsTrue()
 	}
 
+	triBool = context.Generic("skip-no-files").(*TriBool)
+	if triBool.IsSet() {
+		newPreference.SkipNoFiles = triBool.IsTrue()
+	}
+
 	key := context.String("key")
 	value := context.String("value")
 
@@ -652,6 +657,7 @@ func backupRepository(context *cli.Context) {
 
 	backupManager.SetupSnapshotCache(preference.Name)
 	backupManager.SetDryRun(dryRun)
+	backupManager.SetSkipNoFiles(preference.SkipNoFiles)
 	backupManager.Backup(repository, quickMode, threads, context.String("t"), showStatistics, enableVSS)
 
 	runScript(context, preference.Name, "post")
@@ -1661,6 +1667,12 @@ func main() {
 				cli.GenericFlag{
 					Name:  "no-save-password",
 					Usage: "don't save password or access keys to keychain/keyring",
+					Value: &TriBool{},
+					Arg:   "true",
+				},
+				cli.GenericFlag{
+					Name:  "skip-no-files",
+					Usage: "Skip backup if there are no files to backup",
 					Value: &TriBool{},
 					Arg:   "true",
 				},

--- a/src/duplicacy_config.go
+++ b/src/duplicacy_config.go
@@ -68,6 +68,7 @@ type Config struct {
 	chunkPool      chan *Chunk
 	numberOfChunks int32
 	dryRun         bool
+	skipNoFiles         bool
 }
 
 // Create an alias to avoid recursive calls on Config.MarshalJSON

--- a/src/duplicacy_preference.go
+++ b/src/duplicacy_preference.go
@@ -22,6 +22,7 @@ type Preference struct {
 	BackupProhibited  bool              `json:"no_backup"`
 	RestoreProhibited bool              `json:"no_restore"`
 	DoNotSavePassword bool              `json:"no_save_password"`
+	SkipNoFiles       bool              `json:"skip_no_files"`
 	Keys              map[string]string `json:"keys"`
 }
 


### PR DESCRIPTION
Maybe someone else out there also has folders that are used but doesn't change often.  

This is so you can use "duplicacy set -skip-no-files=true" and get it to skip the backup if there is nothing to backup.  So it avoids having lots of blank revisions with nothing in them.


Added skip_no_files in preferences file.
Added option: set -skip-no-files