### PR TITLE
Add -comment capability to allow for duplicacy jobs to be identified with 'ps'

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The key idea of **[Lock-Free Deduplication](https://github.com/gilbertchen/dupli
 
 * [A brief introduction](https://github.com/gilbertchen/duplicacy/wiki/Quick-Start)
 * [Command references](https://github.com/gilbertchen/duplicacy/wiki)
+* [Building from source](https://github.com/gilbertchen/duplicacy/wiki/Installation)
 
 ## Storages
 

--- a/duplicacy/duplicacy_main.go
+++ b/duplicacy/duplicacy_main.go
@@ -1846,7 +1846,11 @@ func main() {
 			Usage:    "enable the profiling tool and listen on the specified address:port",
 			Argument: "<address:port>",
 		},
-}
+		cli.StringFlag{
+			Name:	"comment",
+			Usage:	"value that is ignored by duplicity (useful for identifying process)",
+		},
+	}
 
 	app.HideVersion = true
 	app.Name = "duplicacy"


### PR DESCRIPTION
@gilbertchen 

Two commits here:

1. Minor change to README.md to reference how to build `Duplicacy`.
2. Added `-comment` qualifier as per issue #384 

Given that you have changes I need not currently committed (identified in #361), a new build of duplicacy for the Mac with this change would be awesome, thanks in advance.