### PR TITLE
enum command: useful for debugging filter patterns

### DIFF
--- a/duplicacy/duplicacy_main.go
+++ b/duplicacy/duplicacy_main.go
@@ -885,7 +885,7 @@ func listFiles(context *cli.Context) {
 		return
 	}
     
-    _, _, _, err = duplicacy.CreateSnapshotFromDirectoryFiterDebug("", top, filterDebugOptions)
+    _, _, _, err = duplicacy.CreateSnapshotFromDirectoryFilterDebug("", top, filterDebugOptions)
     
 	if err != nil {
         duplicacy.LOG_ERROR("SNAPSHOT_LIST", "Failed to list the directory %s: %v", top, err)

--- a/src/duplicacy_snapshot.go
+++ b/src/duplicacy_snapshot.go
@@ -55,9 +55,10 @@ func CreateEmptySnapshot(id string) (snapshto *Snapshot) {
 	}
 }
 
-// CreateSnapshotFromDirectory creates a snapshot from the local directory 'top'.  Only 'Files'
-// will be constructed, while 'ChunkHashes' and 'ChunkLengths' can only be populated after uploading.
-func CreateSnapshotFromDirectory(id string, top string) (snapshot *Snapshot, skippedDirectories []string,
+// CreateSnapshotFromDirectoryFilterDebug creates a snapshot from the local directory 'top', optionally
+// logging information useful for debugging filter patterns.  Only 'Files' will be constructed, while
+// 'ChunkHashes' and 'ChunkLengths' can only be populated after uploading.
+func CreateSnapshotFromDirectoryFiterDebug(id string, top string, filterDebugOptions *FilterDebugOptions) (snapshot *Snapshot, skippedDirectories []string,
 	skippedFiles []string, err error) {
 
 	snapshot = &Snapshot{
@@ -125,7 +126,7 @@ func CreateSnapshotFromDirectory(id string, top string) (snapshot *Snapshot, ski
 		directory := directories[len(directories)-1]
 		directories = directories[:len(directories)-1]
 		snapshot.Files = append(snapshot.Files, directory)
-		subdirectories, skipped, err := ListEntries(top, directory.Path, &snapshot.Files, patterns, snapshot.discardAttributes)
+		subdirectories, skipped, err := ListEntries(top, directory.Path, &snapshot.Files, patterns, snapshot.discardAttributes, filterDebugOptions)
 		if err != nil {
 			LOG_WARN("LIST_FAILURE", "Failed to list subdirectory: %v", err)
 			skippedDirectories = append(skippedDirectories, directory.Path)
@@ -148,6 +149,13 @@ func CreateSnapshotFromDirectory(id string, top string) (snapshot *Snapshot, ski
 	snapshot.Files = snapshot.Files[1:]
 
 	return snapshot, skippedDirectories, skippedFiles, nil
+}
+
+// CreateSnapshotFromDirectory creates a snapshot from the local directory 'top'.  Only 'Files'
+// will be constructed, while 'ChunkHashes' and 'ChunkLengths' can only be populated after uploading.
+func CreateSnapshotFromDirectory(id string, top string) (snapshot *Snapshot, skippedDirectories []string,
+	skippedFiles []string, err error) {
+    return CreateSnapshotFromDirectoryFiterDebug(id, top, nil)
 }
 
 // This is the struct used to save/load incomplete snapshots

--- a/src/duplicacy_snapshot.go
+++ b/src/duplicacy_snapshot.go
@@ -58,7 +58,7 @@ func CreateEmptySnapshot(id string) (snapshto *Snapshot) {
 // CreateSnapshotFromDirectoryFilterDebug creates a snapshot from the local directory 'top', optionally
 // logging information useful for debugging filter patterns.  Only 'Files' will be constructed, while
 // 'ChunkHashes' and 'ChunkLengths' can only be populated after uploading.
-func CreateSnapshotFromDirectoryFiterDebug(id string, top string, filterDebugOptions *FilterDebugOptions) (snapshot *Snapshot, skippedDirectories []string,
+func CreateSnapshotFromDirectoryFilterDebug(id string, top string, filterDebugOptions *FilterDebugOptions) (snapshot *Snapshot, skippedDirectories []string,
 	skippedFiles []string, err error) {
 
 	snapshot = &Snapshot{
@@ -155,7 +155,7 @@ func CreateSnapshotFromDirectoryFiterDebug(id string, top string, filterDebugOpt
 // will be constructed, while 'ChunkHashes' and 'ChunkLengths' can only be populated after uploading.
 func CreateSnapshotFromDirectory(id string, top string) (snapshot *Snapshot, skippedDirectories []string,
 	skippedFiles []string, err error) {
-    return CreateSnapshotFromDirectoryFiterDebug(id, top, nil)
+    return CreateSnapshotFromDirectoryFilterDebug(id, top, nil)
 }
 
 // This is the struct used to save/load incomplete snapshots


### PR DESCRIPTION
This implements a new command, `enum`, which provides functionality useful for debugging filter patterns.

This command essentially executes just `CreateSnapshotFromDirectory()` (albeit a new version called `CreateSnapshotFromDirectoryFilterDebug()`) on the repository directory, but provides additional options for logging the snapshot creation process. For example:

* You can list entries included or excluded from the snapshot by the active filter patterns.
* You can list entries explicitly affected by a filter pattern or those implicitly processed by default.
* You can list files, directories, or both.

The output prints whether the entry is included or excluded in the snapshot, the rule (if any) that caused the entry to be included or excluded, and the full path of the entry. Output is tab-delimited, for ease of importing into a spreadsheet for further analysis.

    NAME:
       duplicacy enum - enumerate the the repository
    
    USAGE:
       duplicacy enum [command options]
    
    OPTIONS:
       -all                 DEFAULT: include any file or directory (equivalent to -explicit -implicit)
       -explicit            include files or directories affected by a pattern in the filters file (explicit processing)
       -implicit            include files or directories not affected by any pattern in the filters file (implicit processing)
       -entries, -e         DEFAULT: list files and directories (equivalent to -ientries -xentries)
       -ientries, -ie       list included files and directories (equivalent to -ifiles -idirs)
       -xentries, -xe       list excluded files and directories (equivalent to -xfiles -xdirs)
       -files, -f           list files (equivalent to -ifiles -xfiles)
       -ifiles, -if         list included files
       -xfiles, -xf         list excluded files
       -dirs, -d            list directories (equivalent to -idirs -xdirs)
       -idirs, -id          list included directories
       -xdirs, -xd          list excluded directories
