### PR TITLE
Fixed restoration of basic UNIX file permissions

### DIFF
--- a/src/duplicacy_entry.go
+++ b/src/duplicacy_entry.go
@@ -22,6 +22,9 @@ import (
 var DUPLICACY_DIRECTORY = ".duplicacy"
 var DUPLICACY_FILE = ".duplicacy"
 
+// Mask for file permission bits
+var fileModeMask = os.ModePerm | os.ModeSetuid | os.ModeSetgid | os.ModeSticky
+
 // Regex for matching 'StartChunk:StartOffset:EndChunk:EndOffset'
 var contentRegex = regexp.MustCompile(`^([0-9]+):([0-9]+):([0-9]+):([0-9]+)`)
 
@@ -269,7 +272,7 @@ func (entry *Entry) IsLink() bool {
 }
 
 func (entry *Entry) GetPermissions() os.FileMode {
-	return os.FileMode(entry.Mode) & os.ModePerm
+	return os.FileMode(entry.Mode)&fileModeMask
 }
 
 func (entry *Entry) IsSameAs(other *Entry) bool {
@@ -297,7 +300,14 @@ func (entry *Entry) RestoreMetadata(fullPath string, fileInfo *os.FileInfo, setO
 		}
 	}
 
-	if (*fileInfo).Mode()&os.ModePerm != entry.GetPermissions() {
+	// Note that chown can remove setuid/setgid bits so should be called before chmod
+	if setOwner {
+		if !SetOwner(fullPath, entry, fileInfo) {
+			return false
+		}
+	}
+
+	if (*fileInfo).Mode()&fileModeMask != entry.GetPermissions() {
 		err := os.Chmod(fullPath, entry.GetPermissions())
 		if err != nil {
 			LOG_ERROR("RESTORE_CHMOD", "Failed to set the file permissions: %v", err)
@@ -318,11 +328,7 @@ func (entry *Entry) RestoreMetadata(fullPath string, fileInfo *os.FileInfo, setO
 		entry.SetAttributesToFile(fullPath)
 	}
 
-	if setOwner {
-		return SetOwner(fullPath, entry, fileInfo)
-	} else {
-		return true
-	}
+	return true
 }
 
 // Return -1 if 'left' should appear before 'right', 1 if opposite, and 0 if they are the same.


### PR DESCRIPTION
Fixed restoration of setgid/setuid bits (see issue #143)

Now passes Backup-Bouncer's critical basic permissions test