### PR TITLE
Replace special characters in environment variable name with underscores

### DIFF
--- a/src/duplicacy_utils.go
+++ b/src/duplicacy_utils.go
@@ -176,6 +176,15 @@ func GetPasswordFromPreference(preference Preference, passwordType string) strin
 		if password, found := os.LookupEnv(name); found && password != "" {
 			return password
 		}
+
+		re := regexp.MustCompile(`[^a-zA-Z0-9_]`)
+		namePlain := re.ReplaceAllString(name, "_")
+		if namePlain != name {
+			LOG_DEBUG("PASSWORD_ENV_VAR", "Reading the environment variable %s", namePlain)
+			if password, found := os.LookupEnv(namePlain); found && password != "" {
+				return password
+			}
+		}
 	}
 
 	// If the password is stored in the preference, there is no need to include the storage name


### PR DESCRIPTION
If the storage name contains a special character, and the first check for an environment variable does not return a value, this change does an additional check looking for an environment variable with all special characters replaced with underscores.

The duplicacy documentation references example storage names with hyphens such as `webdav-storage` but this is not valid in an environment variable name in Linux/Mac (in most shells). 

With this change duplicacy will look for:
`DUPLICACY_WEBDAV-STORAGE_PASSWORD`
and if not found also look for:
`DUPLLICACY_WEBDAV_STORAGE_PASSWORD`

