### PR TITLE
Snapshot uploaded chunk lengths

### DIFF
--- a/duplicacy/duplicacy_main.go
+++ b/duplicacy/duplicacy_main.go
@@ -713,6 +713,7 @@ func backupRepository(context *cli.Context) {
 	enableVSS := context.Bool("vss")
 	vssTimeout := context.Int("vss-timeout")
 
+	check := context.Bool("check")
 	dryRun := context.Bool("dry-run")
 	uploadRateLimit := context.Int("limit-rate")
 	enumOnly := context.Bool("enum-only")
@@ -722,7 +723,7 @@ func backupRepository(context *cli.Context) {
 
 	backupManager.SetupSnapshotCache(preference.Name)
 	backupManager.SetDryRun(dryRun)
-	backupManager.Backup(repository, quickMode, threads, context.String("t"), showStatistics, enableVSS, vssTimeout, enumOnly)
+	backupManager.Backup(repository, quickMode, threads, context.String("t"), showStatistics, enableVSS, vssTimeout, enumOnly, check)
 
 	runScript(context, preference.Name, "post")
 }
@@ -1394,6 +1395,10 @@ func main() {
 					Value:    0,
 					Usage:    "the maximum upload rate (in kilobytes/sec)",
 					Argument: "<kB/s>",
+				},
+				cli.BoolFlag{
+					Name:  "check",
+					Usage: "check remote chunk lengths",
 				},
 				cli.BoolFlag{
 					Name:  "dry-run",

--- a/src/duplicacy_backupmanager.go
+++ b/src/duplicacy_backupmanager.go
@@ -200,15 +200,18 @@ func (manager *BackupManager) Backup(top string, quickMode bool, threads int, ta
 
 	// This cache contains all chunks referenced by last snasphot. Any other chunks will lead to a call to
 	// UploadChunk.
-	chunkCache := make(map[string]bool)
+	var chunkCache = struct{
+		sync.RWMutex
+		m map[string]SnapshotChunk
+	}{m: make(map[string]SnapshotChunk)}
 
 	var incompleteSnapshot *Snapshot
 
 	// A revision number of 0 means this is the initial backup
 	if remoteSnapshot.Revision > 0 {
 		// Add all chunks in the last snapshot to the cache
-		for _, chunkID := range manager.SnapshotManager.GetSnapshotChunks(remoteSnapshot, true) {
-			chunkCache[chunkID] = true
+		for _, chunk := range manager.SnapshotManager.GetSnapshotChunks(remoteSnapshot, true) {
+			chunkCache.m[chunk.id] = chunk
 		}
 	} else {
 
@@ -221,9 +224,9 @@ func (manager *BackupManager) Backup(top string, quickMode bool, threads int, ta
 		// put them in the cache.
 		if manager.storage.IsFastListing() || incompleteSnapshot != nil {
 			LOG_INFO("BACKUP_LIST", "Listing all chunks")
-			allChunks, _ := manager.SnapshotManager.ListAllFiles(manager.storage, "chunks/")
+			allChunks, allSizes := manager.SnapshotManager.ListAllFiles(manager.storage, "chunks/")
 
-			for _, chunk := range allChunks {
+			for chunkIndex, chunk := range allChunks {
 				if len(chunk) == 0 || chunk[len(chunk)-1] == '/' {
 					continue
 				}
@@ -233,7 +236,7 @@ func (manager *BackupManager) Backup(top string, quickMode bool, threads int, ta
 				}
 
 				chunk = strings.Replace(chunk, "/", "", -1)
-				chunkCache[chunk] = true
+				chunkCache.m[chunk] = SnapshotChunk{chunk, int(allSizes[chunkIndex])}
 			}
 		}
 
@@ -243,7 +246,7 @@ func (manager *BackupManager) Backup(top string, quickMode bool, threads int, ta
 			lastCompleteChunk := -1
 			for i, chunkHash := range incompleteSnapshot.ChunkHashes {
 				chunkID := manager.config.GetChunkIDFromHash(chunkHash)
-				if _, ok := chunkCache[chunkID]; ok {
+				if _, ok := chunkCache.m[chunkID]; ok {
 					lastCompleteChunk = i
 				} else {
 					break
@@ -298,6 +301,18 @@ func (manager *BackupManager) Backup(top string, quickMode bool, threads int, ta
 			totalModifiedFileSize += entry.Size
 		}
 	} else {
+		// @returns true if entry contains chunk upload lengths
+		hasUploadLengths := func(entry *Entry) bool {
+			if len(remoteSnapshot.ChunkUploadLengths) == 0 {
+				return false
+			}
+			for i := entry.StartChunk; i <= entry.EndChunk; i++ {
+				if remoteSnapshot.ChunkUploadLengths[i] < 0  {
+					return false
+				}
+			}
+			return true
+		}
 
 		var i, j int
 		for i < len(localSnapshot.Files) {
@@ -317,7 +332,7 @@ func (manager *BackupManager) Backup(top string, quickMode bool, threads int, ta
 			} else if remote = remoteSnapshot.Files[j]; !remote.IsFile() {
 				j++
 			} else if local.Path == remote.Path {
-				if local.IsSameAs(remote) {
+				if local.IsSameAs(remote) && hasUploadLengths(remote) {
 					local.Hash = remote.Hash
 					local.StartChunk = remote.StartChunk
 					local.StartOffset = remote.StartOffset
@@ -345,6 +360,7 @@ func (manager *BackupManager) Backup(top string, quickMode bool, threads int, ta
 
 	var preservedChunkHashes []string
 	var preservedChunkLengths []int
+	var preservedChunkUploadLengths []int
 
 	// For each preserved file, adjust the StartChunk and EndChunk pointers.  This is done by finding gaps
 	// between these indices and subtracting the number of deleted chunks.
@@ -362,6 +378,7 @@ func (manager *BackupManager) Backup(top string, quickMode bool, threads int, ta
 			}
 			preservedChunkHashes = append(preservedChunkHashes, remoteSnapshot.ChunkHashes[i])
 			preservedChunkLengths = append(preservedChunkLengths, remoteSnapshot.ChunkLengths[i])
+			preservedChunkUploadLengths = append(preservedChunkUploadLengths, remoteSnapshot.ChunkUploadLengths[i])
 		}
 
 		last = entry.EndChunk
@@ -373,6 +390,7 @@ func (manager *BackupManager) Backup(top string, quickMode bool, threads int, ta
 	var uploadedEntries []*Entry
 	var uploadedChunkHashes []string
 	var uploadedChunkLengths []int
+	var uploadedChunkUploadLengths []int
 	var uploadedChunkLock = &sync.Mutex{}
 
 	// Set all file sizes to -1 to indicate they haven't been processed.   This must be done before creating the file
@@ -429,10 +447,13 @@ func (manager *BackupManager) Backup(top string, quickMode bool, threads int, ta
 							localSnapshot.ChunkHashes = append(localSnapshot.ChunkHashes, uploadedChunkHashes...)
 							localSnapshot.ChunkLengths = preservedChunkLengths
 							localSnapshot.ChunkLengths = append(localSnapshot.ChunkLengths, uploadedChunkLengths...)
+							localSnapshot.ChunkUploadLengths = preservedChunkUploadLengths
+							localSnapshot.ChunkUploadLengths = append(localSnapshot.ChunkUploadLengths, uploadedChunkUploadLengths...)
 						} else {
 							//localSnapshot.Files = uploadedEntries
 							localSnapshot.ChunkHashes = uploadedChunkHashes
 							localSnapshot.ChunkLengths = uploadedChunkLengths
+							localSnapshot.ChunkUploadLengths = uploadedChunkUploadLengths
 						}
 						uploadedChunkLock.Unlock()
 					}
@@ -470,6 +491,12 @@ func (manager *BackupManager) Backup(top string, quickMode bool, threads int, ta
 				}
 			}
 
+			if uploadSize > 0 {
+				chunkCache.Lock()
+				chunkCache.m[chunk.id] = SnapshotChunk{chunk.id, uploadSize}
+				chunkCache.Unlock()
+			}
+
 			uploadedModifiedFileSize := atomic.AddInt64(&uploadedModifiedFileSize, int64(chunkSize))
 
 			if (IsTracing() || showStatistics) && totalModifiedFileSize > 0 {
@@ -504,7 +531,9 @@ func (manager *BackupManager) Backup(top string, quickMode bool, threads int, ta
 
 				chunkIndex++
 
-				_, found := chunkCache[chunkID]
+				chunkCache.RLock()
+				cachedChunk, found := chunkCache.m[chunkID]
+				chunkCache.RUnlock()
 				if found {
 					if time.Now().Unix()-lastUploadingTime > keepUploadAlive {
 						LOG_INFO("UPLOAD_KEEPALIVE", "Skip chunk cache to keep connection alive")
@@ -513,11 +542,12 @@ func (manager *BackupManager) Backup(top string, quickMode bool, threads int, ta
 				}
 
 				if found {
-					completionFunc(chunk, chunkIndex, true, chunkSize, 0)
+					completionFunc(chunk, chunkIndex, true, chunkSize, cachedChunk.uploadLength)
 				} else {
 					lastUploadingTime = time.Now().Unix()
-					chunkCache[chunkID] = true
-
+					chunkCache.Lock();
+					chunkCache.m[chunkID] = SnapshotChunk{chunkID, -1}
+					chunkCache.Unlock();
 					chunkUploader.StartChunk(chunk, chunkIndex)
 				}
 
@@ -525,6 +555,7 @@ func (manager *BackupManager) Backup(top string, quickMode bool, threads int, ta
 				uploadedChunkLock.Lock()
 				uploadedChunkHashes = append(uploadedChunkHashes, hash)
 				uploadedChunkLengths = append(uploadedChunkLengths, chunkSize)
+				// uploadedChunkUploadLengths populated below
 				uploadedChunkLock.Unlock()
 
 				if len(uploadedChunkHashes) == chunkToFail {
@@ -565,6 +596,15 @@ func (manager *BackupManager) Backup(top string, quickMode bool, threads int, ta
 		//
 		// Therefore, we saved uploaded entries and then do a loop here to set offsets for them.
 		setEntryContent(uploadedEntries, uploadedChunkLengths, len(preservedChunkHashes))
+
+		// populate uploaded (compressed) chunk lengths
+		for _, chunkHash := range uploadedChunkHashes {
+			uploadLength := -1
+			chunkID := manager.config.GetChunkIDFromHash(chunkHash)
+			cachedChunk, ok := chunkCache.m[chunkID]
+			if ok { uploadLength = cachedChunk.uploadLength }
+			uploadedChunkUploadLengths = append(uploadedChunkUploadLengths, uploadLength)
+		}
 	}
 
 	if len(preservedChunkHashes) > 0 {
@@ -572,9 +612,12 @@ func (manager *BackupManager) Backup(top string, quickMode bool, threads int, ta
 		localSnapshot.ChunkHashes = append(localSnapshot.ChunkHashes, uploadedChunkHashes...)
 		localSnapshot.ChunkLengths = preservedChunkLengths
 		localSnapshot.ChunkLengths = append(localSnapshot.ChunkLengths, uploadedChunkLengths...)
+		localSnapshot.ChunkUploadLengths = preservedChunkUploadLengths
+		localSnapshot.ChunkUploadLengths = append(localSnapshot.ChunkUploadLengths, uploadedChunkUploadLengths...)
 	} else {
 		localSnapshot.ChunkHashes = uploadedChunkHashes
 		localSnapshot.ChunkLengths = uploadedChunkLengths
+		localSnapshot.ChunkUploadLengths = uploadedChunkUploadLengths
 	}
 
 	localSnapshotReady = true
@@ -625,7 +668,7 @@ func (manager *BackupManager) Backup(top string, quickMode bool, threads int, ta
 
 	totalSnapshotChunkLength, numberOfNewSnapshotChunks,
 		totalUploadedSnapshotChunkLength, totalUploadedSnapshotChunkBytes :=
-		manager.UploadSnapshot(chunkMaker, chunkUploader, top, localSnapshot, chunkCache)
+		manager.UploadSnapshot(chunkMaker, chunkUploader, top, localSnapshot, chunkCache.m)
 
 	if showStatistics && !RunInBackground {
 		for _, entry := range uploadedEntries {
@@ -651,7 +694,7 @@ func (manager *BackupManager) Backup(top string, quickMode bool, threads int, ta
 	RemoveIncompleteSnapshot()
 
 	totalSnapshotChunks := len(localSnapshot.FileSequence) + len(localSnapshot.ChunkSequence) +
-		len(localSnapshot.LengthSequence)
+		len(localSnapshot.LengthSequence) + len(localSnapshot.UploadLengthSequence)
 	if showStatistics {
 
 		LOG_INFO("BACKUP_STATS", "Files: %d total, %s bytes; %d new, %s bytes",
@@ -1023,7 +1066,7 @@ func (encoder *fileEncoder) NextFile() (io.Reader, bool) {
 // UploadSnapshot uploads the specified snapshot to the storage. It turns Files, ChunkHashes, and ChunkLengths into
 // sequences of chunks, and uploads these chunks, and finally the snapshot file.
 func (manager *BackupManager) UploadSnapshot(chunkMaker *ChunkMaker, uploader *ChunkUploader, top string, snapshot *Snapshot,
-	chunkCache map[string]bool) (totalSnapshotChunkSize int64,
+	chunkCache map[string]SnapshotChunk) (totalSnapshotChunkSize int64,
 	numberOfNewSnapshotChunks int, totalUploadedSnapshotChunkSize int64,
 	totalUploadedSnapshotChunkBytes int64) {
 
@@ -1056,8 +1099,8 @@ func (manager *BackupManager) UploadSnapshot(chunkMaker *ChunkMaker, uploader *C
 			func(chunk *Chunk, final bool) {
 				totalSnapshotChunkSize += int64(chunk.GetLength())
 				chunkID := chunk.GetID()
-				if _, found := chunkCache[chunkID]; found {
-					completionFunc(chunk, 0, true, chunk.GetLength(), 0)
+				if cachedChunk, found := chunkCache[chunkID]; found {
+					completionFunc(chunk, 0, true, chunk.GetLength(), cachedChunk.uploadLength)
 				} else {
 					uploader.StartChunk(chunk, len(sequence))
 				}
@@ -1068,7 +1111,7 @@ func (manager *BackupManager) UploadSnapshot(chunkMaker *ChunkMaker, uploader *C
 		return sequence
 	}
 
-	sequences := []string{"chunks", "lengths"}
+	sequences := []string{"chunks", "lengths", "upload-lengths"}
 	// The file list is assumed not to be too large when fixed-size chunking is used
 	if chunkMaker.minimumChunkSize == chunkMaker.maximumChunkSize {
 		sequences = append(sequences, "files")
@@ -1600,6 +1643,12 @@ func (manager *BackupManager) CopySnapshots(otherManager *BackupManager, snapsho
 		}
 
 		for _, chunkHash := range snapshot.LengthSequence {
+			if _, found := chunks[chunkHash]; !found {
+				chunks[chunkHash] = true
+			}
+		}
+
+		for _, chunkHash := range snapshot.UploadLengthSequence {
 			if _, found := chunks[chunkHash]; !found {
 				chunks[chunkHash] = true
 			}

--- a/src/duplicacy_backupmanager_test.go
+++ b/src/duplicacy_backupmanager_test.go
@@ -243,7 +243,7 @@ func TestBackupManager(t *testing.T) {
 	backupManager.SetupSnapshotCache("default")
 
 	SetDuplicacyPreferencePath(testDir + "/repository1/.duplicacy")
-	backupManager.Backup(testDir+"/repository1" /*quickMode=*/, true, threads, "first", false, false, 0, false)
+	backupManager.Backup(testDir+"/repository1" /*quickMode=*/, true, threads, "first", false, false, 0, false, false)
 	time.Sleep(time.Duration(delay) * time.Second)
 	SetDuplicacyPreferencePath(testDir + "/repository2/.duplicacy")
 	backupManager.Restore(testDir+"/repository2", threads, /*inPlace=*/false, /*quickMode=*/false, threads, /*overwrite=*/true,
@@ -267,7 +267,7 @@ func TestBackupManager(t *testing.T) {
 	modifyFile(testDir+"/repository1/dir1/file3", 0.3)
 
 	SetDuplicacyPreferencePath(testDir + "/repository1/.duplicacy")
-	backupManager.Backup(testDir+"/repository1" /*quickMode=*/, true, threads, "second", false, false, 0, false)
+	backupManager.Backup(testDir+"/repository1" /*quickMode=*/, true, threads, "second", false, false, 0, false, false)
 	time.Sleep(time.Duration(delay) * time.Second)
 	SetDuplicacyPreferencePath(testDir + "/repository2/.duplicacy")
 	backupManager.Restore(testDir+"/repository2", 2, /*inPlace=*/true, /*quickMode=*/true, threads, /*overwrite=*/true,
@@ -287,7 +287,7 @@ func TestBackupManager(t *testing.T) {
 	os.Mkdir(testDir+"/repository1/dir2/dir3", 0700)
 	os.Mkdir(testDir+"/repository1/dir4", 0700)
 	SetDuplicacyPreferencePath(testDir + "/repository1/.duplicacy")
-	backupManager.Backup(testDir+"/repository1" /*quickMode=*/, false, threads, "third", false, false, 0, false)
+	backupManager.Backup(testDir+"/repository1" /*quickMode=*/, false, threads, "third", false, false, 0, false, false)
 	time.Sleep(time.Duration(delay) * time.Second)
 
 	// Create some directories and files under repository2 that will be deleted during restore
@@ -350,7 +350,7 @@ func TestBackupManager(t *testing.T) {
 	}
 	backupManager.SnapshotManager.CheckSnapshots( /*snapshotID*/ "host1" /*revisions*/, []int{2, 3} /*tag*/, "",
 		/*showStatistics*/ false /*showTabular*/, false /*checkFiles*/, false /*searchFossils*/, false /*resurrect*/, false)
-	backupManager.Backup(testDir+"/repository1" /*quickMode=*/, false, threads, "fourth", false, false, 0, false)
+	backupManager.Backup(testDir+"/repository1" /*quickMode=*/, false, threads, "fourth", false, false, 0, false, false)
 	backupManager.SnapshotManager.PruneSnapshots("host1", "host1" /*revisions*/, nil /*tags*/, nil /*retentions*/, nil,
 		/*exhaustive*/ false /*exclusive=*/, true /*ignoredIDs*/, nil /*dryRun*/, false /*deleteOnly*/, false /*collectOnly*/, false, 1)
 	numberOfSnapshots = backupManager.SnapshotManager.ListSnapshots( /*snapshotID*/ "host1" /*revisionsToList*/, nil /*tag*/, "" /*showFiles*/, false /*showChunks*/, false)

--- a/src/duplicacy_snapshotmanager.go
+++ b/src/duplicacy_snapshotmanager.go
@@ -343,6 +343,9 @@ func (manager *SnapshotManager) DownloadSnapshotSequence(snapshot *Snapshot, seq
 	if sequenceType == "lengths" {
 		sequence = snapshot.LengthSequence
 		loadFunc = snapshot.LoadLengths
+	} else if sequenceType == "upload-lengths" {
+		sequence = snapshot.UploadLengthSequence
+		loadFunc = snapshot.LoadUploadLengths
 	}
 
 	content := manager.DownloadSequence(sequence)
@@ -370,6 +373,9 @@ func (manager *SnapshotManager) DownloadSnapshotContents(snapshot *Snapshot, pat
 	manager.DownloadSnapshotFileSequence(snapshot, patterns, attributesNeeded)
 	manager.DownloadSnapshotSequence(snapshot, "chunks")
 	manager.DownloadSnapshotSequence(snapshot, "lengths")
+	if len(snapshot.UploadLengthSequence) > 0 {
+		manager.DownloadSnapshotSequence(snapshot, "upload-lengths")
+	}
 
 	err := manager.CheckSnapshot(snapshot)
 	if err != nil {
@@ -405,8 +411,8 @@ func (manager *SnapshotManager) CleanSnapshotCache(latestSnapshot *Snapshot, all
 	chunks := make(map[string]bool)
 
 	if latestSnapshot != nil {
-		for _, chunkID := range manager.GetSnapshotChunks(latestSnapshot, true) {
-			chunks[chunkID] = true
+		for _, chunk := range manager.GetSnapshotChunks(latestSnapshot, true) {
+			chunks[chunk.id] = true
 		}
 	}
 
@@ -615,20 +621,25 @@ func (manager *SnapshotManager) ListAllFiles(storage Storage, top string) (allFi
 	return allFiles, allSizes
 }
 
+type SnapshotChunk struct {
+	id string
+	uploadLength int
+}
+
 // GetSnapshotChunks returns all chunks referenced by a given snapshot. If
-// keepChunkHashes is true, snapshot.ChunkHashes will be populated.
-func (manager *SnapshotManager) GetSnapshotChunks(snapshot *Snapshot, keepChunkHashes bool) (chunks []string) {
+// keepChunkHashes is true, snapshot.ChunkHashes & snapshot.ChunkUploadLengths will be populated.
+func (manager *SnapshotManager) GetSnapshotChunks(snapshot *Snapshot, keepChunkHashes bool) (chunks []SnapshotChunk) {
 
 	for _, chunkHash := range snapshot.FileSequence {
-		chunks = append(chunks, manager.config.GetChunkIDFromHash(chunkHash))
+		chunks = append(chunks, SnapshotChunk{manager.config.GetChunkIDFromHash(chunkHash), -1})
 	}
 
 	for _, chunkHash := range snapshot.ChunkSequence {
-		chunks = append(chunks, manager.config.GetChunkIDFromHash(chunkHash))
+		chunks = append(chunks, SnapshotChunk{manager.config.GetChunkIDFromHash(chunkHash), -1})
 	}
 
 	for _, chunkHash := range snapshot.LengthSequence {
-		chunks = append(chunks, manager.config.GetChunkIDFromHash(chunkHash))
+		chunks = append(chunks, SnapshotChunk{manager.config.GetChunkIDFromHash(chunkHash), -1})
 	}
 
 	if len(snapshot.ChunkHashes) == 0 {
@@ -642,8 +653,31 @@ func (manager *SnapshotManager) GetSnapshotChunks(snapshot *Snapshot, keepChunkH
 		}
 	}
 
-	for _, chunkHash := range snapshot.ChunkHashes {
-		chunks = append(chunks, manager.config.GetChunkIDFromHash(chunkHash))
+	if len(snapshot.ChunkUploadLengths) == 0 {
+		if len(snapshot.UploadLengthSequence) > 0 {
+			description := manager.DownloadSequence(snapshot.UploadLengthSequence)
+			err := snapshot.LoadUploadLengths(description)
+			if err != nil {
+				LOG_ERROR("SNAPSHOT_CHUNK", "Failed to load chunk upload lengths for snapshot %s at revision %d: %v",
+					snapshot.ID, snapshot.Revision, err)
+				return nil
+			}
+		} else {
+			snapshot.ChunkUploadLengths = make([]int, len(snapshot.ChunkHashes))
+			for i, _ := range snapshot.ChunkUploadLengths { snapshot.ChunkUploadLengths[i] = -1 }
+		}
+	}
+
+	if len(snapshot.ChunkHashes) != len(snapshot.ChunkUploadLengths) {
+		LOG_ERROR("SNAPSHOT_CHUNK", "Number of hashes (%d) does not match number of lengths (%d) for snapshot %s at revision %d",
+			len(snapshot.ChunkHashes), len(snapshot.ChunkUploadLengths), snapshot.ID, snapshot.Revision)
+		return nil
+	}
+
+	for chunkIndex, chunkHash := range snapshot.ChunkHashes {
+		chunks = append(chunks, SnapshotChunk{
+			manager.config.GetChunkIDFromHash(chunkHash),
+			snapshot.ChunkUploadLengths[chunkIndex]})
 	}
 
 	if !keepChunkHashes {
@@ -732,14 +766,18 @@ func (manager *SnapshotManager) ListSnapshots(snapshotID string, revisionsToList
 					}
 				}
 
-				metaChunks := len(snapshot.FileSequence) + len(snapshot.ChunkSequence) + len(snapshot.LengthSequence)
+				metaChunks := len(snapshot.FileSequence) + len(snapshot.ChunkSequence) + len(snapshot.LengthSequence) + len(snapshot.UploadLengthSequence)
 				LOG_INFO("SNAPSHOT_STATS", "Files: %d, total size: %d, file chunks: %d, metadata chunks: %d",
 					totalFiles, totalFileSize, lastChunk+1, metaChunks)
 			}
 
 			if showChunks {
-				for _, chunkID := range manager.GetSnapshotChunks(snapshot, false) {
-					LOG_INFO("SNAPSHOT_CHUNKS", "chunk: %s", chunkID)
+				for _, chunk := range manager.GetSnapshotChunks(snapshot, false) {
+					chunkStr := fmt.Sprintf("chunk: %s", chunk.id)
+					if chunk.uploadLength >= 0 {
+						chunkStr += fmt.Sprintf(" (%d bytes)", chunk.uploadLength)
+					}
+					LOG_INFO("SNAPSHOT_CHUNKS", "%s", chunkStr)
 				}
 			}
 
@@ -828,29 +866,32 @@ func (manager *SnapshotManager) CheckSnapshots(snapshotID string, revisionsToChe
 				continue
 			}
 
-			chunks := make(map[string]bool)
-			for _, chunkID := range manager.GetSnapshotChunks(snapshot, false) {
-				chunks[chunkID] = true
-			}
-
+			invalidChunks := 0
 			missingChunks := 0
-			for chunkID, _ := range chunks {
+			for _, chunk := range manager.GetSnapshotChunks(snapshot, false) {
+				chunkSize, found := chunkSizeMap[chunk.id]
 
-				_, found := chunkSizeMap[chunkID]
-
-				if !found {
+				if found {
+					if chunk.uploadLength >= 0 && int(chunkSize) != chunk.uploadLength {
+						invalidChunks += 1
+						LOG_WARN("SNAPSHOT_VALIDATE",
+							"Chunk %s referenced by snapshot %s at revision %d expected size %d but actual is %d",
+							chunk.id, snapshotID, revision, chunk.uploadLength, chunkSize)
+						continue
+					}
+				} else {
 					if !searchFossils {
 						missingChunks += 1
 						LOG_WARN("SNAPSHOT_VALIDATE",
 							"Chunk %s referenced by snapshot %s at revision %d does not exist",
-							chunkID, snapshotID, revision)
+							chunk.id, snapshotID, revision)
 						continue
 					}
 
-					chunkPath, exist, size, err := manager.storage.FindChunk(0, chunkID, true)
+					chunkPath, exist, size, err := manager.storage.FindChunk(0, chunk.id, true)
 					if err != nil {
 						LOG_ERROR("SNAPSHOT_VALIDATE", "Failed to check the existence of chunk %s: %v",
-							chunkID, err)
+							chunk.id, err)
 						return false
 					}
 
@@ -858,37 +899,37 @@ func (manager *SnapshotManager) CheckSnapshots(snapshotID string, revisionsToChe
 						missingChunks += 1
 						LOG_WARN("SNAPSHOT_VALIDATE",
 							"Chunk %s referenced by snapshot %s at revision %d does not exist",
-							chunkID, snapshotID, revision)
+							chunk.id, snapshotID, revision)
 						continue
 					}
 
 					if resurrect {
-						manager.resurrectChunk(chunkPath, chunkID)
+						manager.resurrectChunk(chunkPath, chunk.id)
 					} else {
 						LOG_WARN("SNAPSHOT_FOSSIL", "Chunk %s referenced by snapshot %s at revision %d "+
-							"has been marked as a fossil", chunkID, snapshotID, revision)
+							"has been marked as a fossil", chunk.id, snapshotID, revision)
 					}
 
-					chunkSizeMap[chunkID] = size
+					chunkSizeMap[chunk.id] = size
 				}
 
-				if unique, found := chunkUniqueMap[chunkID]; !found {
-					chunkUniqueMap[chunkID] = true
+				if unique, found := chunkUniqueMap[chunk.id]; !found {
+					chunkUniqueMap[chunk.id] = true
 				} else {
 					if unique {
-						chunkUniqueMap[chunkID] = false
+						chunkUniqueMap[chunk.id] = false
 					}
 				}
 
-				if previousSnapshotIDIndex, found := chunkSnapshotMap[chunkID]; !found {
-					chunkSnapshotMap[chunkID] = snapshotIDIndex
+				if previousSnapshotIDIndex, found := chunkSnapshotMap[chunk.id]; !found {
+					chunkSnapshotMap[chunk.id] = snapshotIDIndex
 				} else if previousSnapshotIDIndex != snapshotIDIndex && previousSnapshotIDIndex != -1 {
-					chunkSnapshotMap[chunkID] = -1
+					chunkSnapshotMap[chunk.id] = -1
 				}
 			}
 
-			if missingChunks > 0 {
-				LOG_WARN("SNAPSHOT_CHECK", "Some chunks referenced by snapshot %s at revision %d are missing",
+			if invalidChunks > 0 || missingChunks > 0 {
+				LOG_WARN("SNAPSHOT_CHECK", "Some chunks referenced by snapshot %s at revision %d are missing and/or invalid",
 					snapshotID, revision)
 				totalMissingChunks += missingChunks
 			} else {
@@ -924,9 +965,9 @@ func (manager *SnapshotManager) ShowStatistics(snapshotMap map[string][]*Snapsho
 		for _, snapshot := range snapshotList {
 
 			chunks := make(map[string]bool)
-			for _, chunkID := range manager.GetSnapshotChunks(snapshot, false) {
-				chunks[chunkID] = true
-				snapshotChunks[chunkID] = true
+			for _, chunk := range manager.GetSnapshotChunks(snapshot, false) {
+				chunks[chunk.id] = true
+				snapshotChunks[chunk.id] = true
 			}
 
 			var totalChunkSize int64
@@ -977,20 +1018,20 @@ func (manager *SnapshotManager) ShowStatisticsTabular(snapshotMap map[string][]*
 		earliestSeenChunks := make(map[string]int)
 
 		for _, snapshot := range snapshotList {
-			for _, chunkID := range manager.GetSnapshotChunks(snapshot, true) {
-				if earliestSeenChunks[chunkID] == 0 {
-					earliestSeenChunks[chunkID] = math.MaxInt32
+			for _, chunk := range manager.GetSnapshotChunks(snapshot, true) {
+				if earliestSeenChunks[chunk.id] == 0 {
+					earliestSeenChunks[chunk.id] = math.MaxInt32
 				}
-				earliestSeenChunks[chunkID] = MinInt(earliestSeenChunks[chunkID], snapshot.Revision)
+				earliestSeenChunks[chunk.id] = MinInt(earliestSeenChunks[chunk.id], snapshot.Revision)
 			}
 		}
 
 		for _, snapshot := range snapshotList {
 
 			chunks := make(map[string]bool)
-			for _, chunkID := range manager.GetSnapshotChunks(snapshot, true) {
-				chunks[chunkID] = true
-				snapshotChunks[chunkID] = true
+			for _, chunk := range manager.GetSnapshotChunks(snapshot, true) {
+				chunks[chunk.id] = true
+				snapshotChunks[chunk.id] = true
 			}
 
 			var totalChunkSize int64
@@ -1069,9 +1110,11 @@ func (manager *SnapshotManager) PrintSnapshot(snapshot *Snapshot) bool {
 	object["file_sequence"] = manager.ConvertSequence(snapshot.FileSequence)
 	object["chunk_sequence"] = manager.ConvertSequence(snapshot.ChunkSequence)
 	object["length_sequence"] = manager.ConvertSequence(snapshot.LengthSequence)
+	object["upload_length_sequence"] = manager.ConvertSequence(snapshot.UploadLengthSequence)
 
 	object["chunks"] = manager.ConvertSequence(snapshot.ChunkHashes)
 	object["lengths"] = snapshot.ChunkLengths
+	object["upload-lengths"] = snapshot.ChunkUploadLengths
 
 	// By default the json serialization of a file entry contains the path in base64 format.  This is
 	// to convert every file entry into an object which include the path in a more readable format.
@@ -1804,7 +1847,7 @@ func (manager *SnapshotManager) PruneSnapshots(selfID string, snapshotID string,
 				fmt.Fprintf(logFile, "Snapshot %s revision %d was created after collection %s\n", newSnapshot.ID, newSnapshot.Revision, collectionName)
 				LOG_INFO("PRUNE_NEWSNAPSHOT", "Snapshot %s revision %d was created after collection %s", newSnapshot.ID, newSnapshot.Revision, collectionName)
 				for _, chunk := range manager.GetSnapshotChunks(newSnapshot, false) {
-					newChunks[chunk] = true
+					newChunks[chunk.id] = true
 				}
 			}
 
@@ -2086,7 +2129,7 @@ func (manager *SnapshotManager) pruneSnapshotsNonExhaustive(allSnapshots map[str
 
 			for _, chunk := range chunks {
 				// The initial value is 'false'.  When a referenced chunk is found it will change the value to 'true'.
-				targetChunks[chunk] = false
+				targetChunks[chunk.id] = false
 			}
 		}
 	}
@@ -2100,8 +2143,8 @@ func (manager *SnapshotManager) pruneSnapshotsNonExhaustive(allSnapshots map[str
 			chunks := manager.GetSnapshotChunks(snapshot, false)
 
 			for _, chunk := range chunks {
-				if _, found := targetChunks[chunk]; found {
-					targetChunks[chunk] = true
+				if _, found := targetChunks[chunk.id]; found {
+					targetChunks[chunk.id] = true
 				}
 			}
 		}
@@ -2158,7 +2201,7 @@ func (manager *SnapshotManager) pruneSnapshotsExhaustive(referencedFossils map[s
 
 			for _, chunk := range chunks {
 				// The initial value is 'false'.  When a referenced chunk is found it will change the value to 'true'.
-				referencedChunks[chunk] = false
+				referencedChunks[chunk.id] = false
 			}
 		}
 	}


### PR DESCRIPTION
Introduces 'upload-lengths' to snapshots; containing an array of the post compression & encryption chunk lengths. These upload lengths can then be used when checking snapshot integrity. Not only verifying that the chunk names are available, but that the chunks are of the expected size.

Additionally adds a '-check' flag to backup. This will check the unchanged, remote chunk lengths, to ensure that they are of the expected length. Remote chunks of an unexpected size will be re-uploaded (self-healing). Check is currently a flag as we do need to first pull down the chunk file list from the remote. Not sure how lengthy/costly an operation this could be? so made it optional.

Remote length checks will be skipped for older pre-existing snapshots lacking 'upload-lengths'. What this means is that the first snapshot to introduce upload-lengths will need to recompute the uploaded chunk lengths. These chunks do not need to be re-uploaded however, unless the lengths of the remote chunks are different than locally computed.