### PR TITLE
Use a small window for calculating current transfer speed for backup

### DIFF
--- a/src/duplicacy_backupmanager.go
+++ b/src/duplicacy_backupmanager.go
@@ -386,7 +386,7 @@ func (manager *BackupManager) Backup(top string, quickMode bool, threads int, ta
 	// is the last file.
 	fileReader := CreateFileReader(shadowTop, modifiedEntries)
 
-	startUploadingTime := time.Now().Unix()
+	//startUploadingTime := time.Now().Unix()
 
 	lastUploadingTime := time.Now().Unix()
 

--- a/src/duplicacy_backupmanager.go
+++ b/src/duplicacy_backupmanager.go
@@ -164,7 +164,7 @@ func setEntryContent(entries []*Entry, chunkLengths []int, offset int) {
 // be scanned to create the snapshot.  'tag' is the tag assigned to the new snapshot.
 func (manager *BackupManager) Backup(top string, quickMode bool, threads int, tag string,
 	showStatistics bool, shadowCopy bool, shadowCopyTimeout int, enumOnly bool) bool {
-	windowedRate := NewWindowedRate(150)
+	windowedRate := NewWindowedRate(100)
 
 	var err error
 	top, err = filepath.Abs(top)

--- a/src/duplicacy_backupmanager.go
+++ b/src/duplicacy_backupmanager.go
@@ -164,7 +164,7 @@ func setEntryContent(entries []*Entry, chunkLengths []int, offset int) {
 // be scanned to create the snapshot.  'tag' is the tag assigned to the new snapshot.
 func (manager *BackupManager) Backup(top string, quickMode bool, threads int, tag string,
 	showStatistics bool, shadowCopy bool, shadowCopyTimeout int, enumOnly bool) bool {
-	windowedRate := NewWindowedRate(1000)
+	windowedRate := NewWindowedRate(150)
 
 	var err error
 	top, err = filepath.Abs(top)

--- a/src/windowed_rate.go
+++ b/src/windowed_rate.go
@@ -60,27 +60,16 @@ It handles the case where the array was not filled completely
 (we are early in the upload)
 */
 func (rpm WindowedRate) ComputeAverage() int64 {
-	latestEntry := rpm.values[rpm.insertIndex].insertedTime
+	latestEntry := rpm.values[rpm.insertIndex]
 
-	firstEntry := rpm.values[0].insertedTime // this handles the case rpm.arraySize < rpm.arrayCapacity
+	firstEntry := rpm.values[0] // this handles the case rpm.arraySize < rpm.arrayCapacity
 	if rpm.arraySize == rpm.arrayCapacity {
-		firstEntry = rpm.values[(rpm.insertIndex+1)%rpm.arrayCapacity].insertedTime
+		firstEntry = rpm.values[(rpm.insertIndex+1)%rpm.arrayCapacity]
 	}
 
-	/**
-	The sum is used to smooth-out random reansfer rate outliers
-	eg.:
-	- previous last and last transfer speeds: 100 MB, 120MB (so 20 MB transferred)
-	- current transfer: 120.1MB (so 0.1 MB transferred)
-	=> if the smoothing would not be applied, there would be a higher drop in transfer speed displayed
-	*/
-	sum := int64(0)
-	for i := 0; i < rpm.arraySize; i++ {
-		sum += rpm.values[i].value
-	}
-	totalTransferred := sum / int64(rpm.arraySize)
+	totalTransferred := latestEntry.value - firstEntry.value
 
-	duration := latestEntry.Unix() - firstEntry.Unix()
+	duration := latestEntry.insertedTime.Unix() - firstEntry.insertedTime.Unix()
 	if duration == 0 {
 		duration = 1
 	}

--- a/src/windowed_rate.go
+++ b/src/windowed_rate.go
@@ -9,6 +9,15 @@ type ratePair struct {
 	value        int64
 }
 
+/**
+The principle of this WindowedRate struct and algorithm is that it
+stores the time instant when a specific value ("uploaded quantity") was inserted,
+computes an average of all those values and then divides that average by how much time
+it took to upload them.
+
+A circular array of fixed length is used so that new records will simply replace the old ones
+as more data is uploaded.
+*/
 type WindowedRate struct {
 	arrayCapacity int
 	insertIndex   int
@@ -30,7 +39,9 @@ func NewWindowedRate(arrayCapacity int) WindowedRate {
 	return rpm
 }
 
-//noinspection GoUnusedExportedFunction,GoUnusedParameter
+/**
+InsertValue inserts a value in the circular array along with the current time
+*/
 func (rpm *WindowedRate) InsertValue(value int64) {
 	rpm.insertIndex = (rpm.insertIndex + 1) % rpm.arrayCapacity
 	if rpm.arraySize < rpm.arrayCapacity {
@@ -40,7 +51,14 @@ func (rpm *WindowedRate) InsertValue(value int64) {
 	rpm.values[rpm.insertIndex] = ratePair{time.Now(), value}
 }
 
-//noinspection GoUnusedExportedFunction,GoUnusedVariable
+/**
+ComputeAverage calculates the average transfer speed between
+the first entry in the array (firstEntry) and
+the last entry in the array (latestEntry).
+
+It handles the case where the array was not filled completely
+(we are early in the upload)
+*/
 func (rpm WindowedRate) ComputeAverage() int64 {
 	latestEntry := rpm.values[rpm.insertIndex].insertedTime
 
@@ -49,6 +67,13 @@ func (rpm WindowedRate) ComputeAverage() int64 {
 		firstEntry = rpm.values[(rpm.insertIndex+1)%rpm.arrayCapacity].insertedTime
 	}
 
+	/**
+	The sum is used to smooth-out random reansfer rate outliers
+	eg.:
+	- previous last and last transfer speeds: 100 MB, 120MB (so 20 MB transferred)
+	- current transfer: 120.1MB (so 0.1 MB transferred)
+	=> if the smoothing would not be applied, there would be a higher drop in transfer speed displayed
+	*/
 	sum := int64(0)
 	for i := 0; i < rpm.arraySize; i++ {
 		sum += rpm.values[i].value

--- a/src/windowed_rate.go
+++ b/src/windowed_rate.go
@@ -1,0 +1,64 @@
+package duplicacy
+
+import (
+	"time"
+)
+
+type ratePair struct {
+	instant time.Time
+	value   int
+}
+
+type WindowedRate struct {
+	arrayCapacity int
+	insertIndex   int
+	arraySize     int
+
+	values []ratePair
+}
+
+func NewWindowedRate(arrayCapacity int) WindowedRate {
+	rpm := WindowedRate{}
+	rpm.arrayCapacity = arrayCapacity
+	rpm.insertIndex = -1
+	rpm.values = make([]ratePair, arrayCapacity)
+
+	for i := 0; i < arrayCapacity; i++ {
+		rpm.values[i].instant = time.Now()
+	}
+
+	return rpm
+}
+
+//noinspection GoUnusedExportedFunction,GoUnusedParameter
+func (rpm *WindowedRate) InsertValue(value int) {
+	rpm.insertIndex = (rpm.insertIndex + 1) % rpm.arrayCapacity
+	if rpm.arraySize < rpm.arrayCapacity {
+		rpm.arraySize++
+	}
+
+	rpm.values[rpm.insertIndex] = ratePair{time.Now(), value}
+}
+
+//noinspection GoUnusedExportedFunction,GoUnusedVariable
+func (rpm WindowedRate) ComputeAverage() float64 {
+	latestEntry := rpm.values[rpm.insertIndex].instant
+
+	earliestEntry := rpm.values[0].instant // this handles the case rpm.arraySize < rpm.arrayCapacity
+	if rpm.arraySize == rpm.arrayCapacity {
+		earliestEntry = rpm.values[(rpm.insertIndex+1)%rpm.arrayCapacity].instant
+	}
+
+	sum := 0
+	for i := 0; i < rpm.arraySize; i++ {
+		sum += rpm.values[i].value
+	}
+
+	duration := latestEntry.Unix() - earliestEntry.Unix()
+	if duration == 0 {
+		duration = 1
+	}
+
+	avg := float64(sum) / float64(duration)
+	return avg
+}


### PR DESCRIPTION
With this I am trying to fix #128: the problem that upload speed is wrong when a large portion of a backup has skipped chunks (eg. 80% of backup is skipped chunks and only 20% are actually uploaded).

I have done this by implementing a circular array which stores the current uploaded MB and the timestamp when they were uploaded, and then calculates the average between the current (latest) record added and the earliest record.

Does this look like a good approach to you?