### PR TITLE
Write a log message if nothing was pruned

### DIFF
--- a/src/duplicacy_snapshotmanager.go
+++ b/src/duplicacy_snapshotmanager.go
@@ -1605,6 +1605,15 @@ func (manager *SnapshotManager) PruneSnapshots(selfID string, snapshotID string,
 
 	defer func() {
 		if logFile != nil {
+
+			// in case nothing was pruned, the log file is empty.
+			// write in the logfile that "nothing was pruned"
+			if stats, e := logFile.Stat(); e == nil {
+				if stats.Size() <= int64(2) {
+					fmt.Fprintf(logFile, "No snapshots or chunks to be pruned in this run")
+				}
+			}
+
 			cerr := logFile.Close()
 			if cerr != nil {
 				LOG_WARN("LOG_FILE", "Could not close log file %s: %v", logFileName, cerr)

--- a/src/duplicacy_snapshotmanager.go
+++ b/src/duplicacy_snapshotmanager.go
@@ -31,7 +31,6 @@ const (
 
 // FossilCollection contains fossils and temporary files found during a snapshot deletions.
 type FossilCollection struct {
-
 	// At what time the fossil collection was finished
 	EndTime int64 `json:"end_time"`
 
@@ -57,7 +56,7 @@ func CreateFossilCollection(allSnapshots map[string][]*Snapshot) *FossilCollecti
 	}
 
 	return &FossilCollection{
-		LastRevisions: lastRevisions,
+		LastRevisions:    lastRevisions,
 		DeletedRevisions: make(map[string][]int),
 	}
 }
@@ -182,7 +181,6 @@ func getDaysBetween(start int64, end int64) int {
 
 // SnapshotManager is mainly responsible for downloading, and deleting snapshots.
 type SnapshotManager struct {
-
 	// These are variables shared with the backup manager
 	config        *Config
 	storage       Storage
@@ -2200,7 +2198,7 @@ func (manager *SnapshotManager) pruneSnapshotsExhaustive(referencedFossils map[s
 						continue
 					}
 
-					manager.chunkOperator.Resurrect(chunk, chunkDir + file)
+					manager.chunkOperator.Resurrect(chunk, chunkDir+file)
 					fmt.Fprintf(logFile, "Found referenced fossil %s\n", file)
 
 				} else {
@@ -2211,7 +2209,7 @@ func (manager *SnapshotManager) pruneSnapshotsExhaustive(referencedFossils map[s
 					}
 
 					if exclusive {
-						manager.chunkOperator.Delete(chunk, chunkDir + file)
+						manager.chunkOperator.Delete(chunk, chunkDir+file)
 					} else {
 						collection.AddFossil(chunkDir + file)
 						LOG_DEBUG("FOSSIL_FIND", "Found unreferenced fossil %s", file)
@@ -2388,7 +2386,7 @@ func (manager *SnapshotManager) DownloadFile(path string, derivationKey string) 
 	}
 
 	if len(derivationKey) > 64 {
-		derivationKey = derivationKey[len(derivationKey) - 64:]
+		derivationKey = derivationKey[len(derivationKey)-64:]
 	}
 
 	err = manager.fileChunk.Decrypt(manager.config.FileKey, derivationKey)
@@ -2422,7 +2420,7 @@ func (manager *SnapshotManager) UploadFile(path string, derivationKey string, co
 	}
 
 	if len(derivationKey) > 64 {
-		derivationKey = derivationKey[len(derivationKey) - 64:]
+		derivationKey = derivationKey[len(derivationKey)-64:]
 	}
 
 	err := manager.fileChunk.Encrypt(manager.config.FileKey, derivationKey)


### PR DESCRIPTION
This should close #424.

---

This is the simplest implementation I could think of. 
There was the alternative to make a boolean and check it at every `fmt.Fprintf` but that meant i had to also modify the methods `pruneSnapshotsExhaustive` and `pruneSnapshotsNonExhaustive` which i don't think is worth it.