### PR TITLE
Improve filter syntax with include files and change exclude behavior of .duplicacy

### DIFF
--- a/src/duplicacy_entry.go
+++ b/src/duplicacy_entry.go
@@ -481,9 +481,6 @@ func ListEntries(top string, path string, fileList *[]*Entry, patterns []string,
 	entries := make([]*Entry, 0, 4)
 
 	for _, f := range files {
-		if (f.Name() == DUPLICACY_DIRECTORY) && (nobackupFile == "") {
-			continue
-		}
 		entry := CreateEntryFromFileInfo(f, normalizedPath)
 		if len(patterns) > 0 && !MatchPath(entry.Path, patterns) {
 			continue

--- a/src/duplicacy_entry.go
+++ b/src/duplicacy_entry.go
@@ -481,7 +481,7 @@ func ListEntries(top string, path string, fileList *[]*Entry, patterns []string,
 	entries := make([]*Entry, 0, 4)
 
 	for _, f := range files {
-		if f.Name() == DUPLICACY_DIRECTORY {
+		if (f.Name() == DUPLICACY_DIRECTORY) && (nobackupFile == "") {
 			continue
 		}
 		entry := CreateEntryFromFileInfo(f, normalizedPath)

--- a/src/duplicacy_utils.go
+++ b/src/duplicacy_utils.go
@@ -474,3 +474,24 @@ func MinInt(x, y int) int {
 	}
 	return y
 }
+
+// Contains tells whether a contains x.
+func Contains(a []string, x string) bool {
+	for _, n := range a {
+		if x == n {
+			return true
+		}
+	}
+	return false
+}
+
+// Find returns the smallest index i at which x == a[i],
+// or len(a) if there is no such index.
+func Find(a []string, x string) int {
+	for i, n := range a {
+		if x == n {
+			return i
+		}
+	}
+	return len(a)
+}


### PR DESCRIPTION
Hi,

I have extended the filter file syntax with a new statement to include another filter file.
Using @<filename>, you can now include other files. Relative paths are supported.
In addition I have changed the exclude behavior for the .duplicacy folder. When using nobackup_file, this folder will not get excluded anymore. I use filters that exclude cache and internal files