### PR TITLE
Filter extension

### DIFF
--- a/duplicacy/duplicacy_main.go
+++ b/duplicacy/duplicacy_main.go
@@ -784,26 +784,16 @@ func restoreRepository(context *cli.Context) {
 			pattern = pattern[1:]
 		}
 
-		if duplicacy.IsUnspecifiedFilter(pattern) {
-			pattern = "+" + pattern
-		}
-
-		if duplicacy.IsEmptyFilter(pattern) {
-			continue
-		}
-
-		if strings.HasPrefix(pattern, "i:") || strings.HasPrefix(pattern, "e:") {
-			valid, err := duplicacy.IsValidRegex(pattern[2:])
-			if !valid || err != nil {
-				duplicacy.LOG_ERROR("SNAPSHOT_FILTER", "Invalid regular expression encountered for filter: \"%s\", error: %v", pattern, err)
-			}
-		}
-
 		patterns = append(patterns, pattern)
 
+	
+
 	}
+	patterns = duplicacy.ProcessFilterLines(patterns, make([]string, 0))
 
 	duplicacy.LOG_DEBUG("REGEX_DEBUG", "There are %d compiled regular expressions stored", len(duplicacy.RegexMap))
+
+	duplicacy.LOG_INFO("SNAPSHOT_FILTER", "Loaded %d include/exclude pattern(s)", len(patterns))
 
 	storage.SetRateLimits(context.Int("limit-rate"), 0)
 	backupManager := duplicacy.CreateBackupManager(preference.SnapshotID, storage, repository, password, preference.NobackupFile)

--- a/src/duplicacy_entry.go
+++ b/src/duplicacy_entry.go
@@ -481,9 +481,6 @@ func ListEntries(top string, path string, fileList *[]*Entry, patterns []string,
 	entries := make([]*Entry, 0, 4)
 
 	for _, f := range files {
-		if (f.Name() == DUPLICACY_DIRECTORY) && (nobackupFile == "") {
-			continue
-		}
 		entry := CreateEntryFromFileInfo(f, normalizedPath)
 		if len(patterns) > 0 && !MatchPath(entry.Path, patterns) {
 			continue

--- a/src/duplicacy_entry.go
+++ b/src/duplicacy_entry.go
@@ -481,6 +481,9 @@ func ListEntries(top string, path string, fileList *[]*Entry, patterns []string,
 	entries := make([]*Entry, 0, 4)
 
 	for _, f := range files {
+		if f.Name() == DUPLICACY_DIRECTORY {
+			continue
+		}
 		entry := CreateEntryFromFileInfo(f, normalizedPath)
 		if len(patterns) > 0 && !MatchPath(entry.Path, patterns) {
 			continue

--- a/src/duplicacy_entry.go
+++ b/src/duplicacy_entry.go
@@ -481,7 +481,7 @@ func ListEntries(top string, path string, fileList *[]*Entry, patterns []string,
 	entries := make([]*Entry, 0, 4)
 
 	for _, f := range files {
-		if f.Name() == DUPLICACY_DIRECTORY {
+		if (f.Name() == DUPLICACY_DIRECTORY) && (nobackupFile == "") {
 			continue
 		}
 		entry := CreateEntryFromFileInfo(f, normalizedPath)

--- a/src/duplicacy_snapshot.go
+++ b/src/duplicacy_snapshot.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -123,17 +122,7 @@ func AppendPattern(patterns []string, new_pattern string) (new_patterns []string
 	return new_patterns
 }
 func ProcessFilters() (patterns []string) {
-	patternFileLines := []string{
-		`# ============================ exclude the internal files and directories in all ".duplicacy" subfolders`,
-		`e:(?i)(^|/)` + regexp.QuoteMeta(DUPLICACY_DIRECTORY) + `/cache/`,
-		`e:(?i)(^|/)` + regexp.QuoteMeta(DUPLICACY_DIRECTORY) + `/temporary$`,
-		`# ============================ exclude the internal files and directories in toplevel ".duplicacy" subfolder`,
-		`e:(?i)^` + regexp.QuoteMeta(DUPLICACY_DIRECTORY) + `/incomplete$`,
-		`e:(?i)^` + regexp.QuoteMeta(DUPLICACY_DIRECTORY) + `/logs/`,
-		"@" + joinPath(GetDuplicacyPreferencePath(), "filters"),
-		}
-	LOG_DEBUG("SNAPSHOT_FILTER", "Adding standard filters ...")
-	patterns = ProcessFilterLines(patternFileLines, make([]string, 0))
+	patterns = ProcessFilterFile(joinPath(GetDuplicacyPreferencePath(), "filters"), make([]string, 0))
 
 	LOG_DEBUG("REGEX_DEBUG", "There are %d compiled regular expressions stored", len(RegexMap))
 

--- a/src/duplicacy_utils.go
+++ b/src/duplicacy_utils.go
@@ -474,3 +474,24 @@ func MinInt(x, y int) int {
 	}
 	return y
 }
+
+// Contains tells whether a contains x.
+func Contains(a []string, x string) bool {
+	for _, n := range a {
+		if x == n {
+			return true
+		}
+	}
+	return false
+}
+
+// Find returns the smallest index i at which x == a[i],
+// or len(a) if there is no such index.
+func Find(a []string, x string) int {
+	for i, n := range a {
+		if x == n {
+			return i
+		}
+	}
+	return len(a)
+}


### PR DESCRIPTION
I have extended the filter file syntax with a new statement to include another filter file.
Using @, you can now include other files. Relative paths are supported and are resolved against the currently processed file.
- You can use this in the filters file
- You can use this at command line for the restore command, to specify the patterns in a file instead of the command line. This is good for windows users, since escaping in cmd.exe is very difficult.
