### PR TITLE
Retry on 408 error from Google Drive (Update to duplicacy_gcdstorage.go)

### DIFF
--- a/src/duplicacy_gcdstorage.go
+++ b/src/duplicacy_gcdstorage.go
@@ -78,6 +78,10 @@ func (storage *GCDStorage) shouldRetry(threadIndex int, err error) (bool, error)
 			// User Rate Limit Exceeded
 			message = e.Message
 			retry = true
+		} else if e.Code == 408 {
+			// Request timeout
+			message = e.Message
+			retry = true
 		} else if e.Code == 401 {
 			// Only retry on authorization error when storage has been connected before
 			if storage.isConnected {


### PR DESCRIPTION
Add automatic retry on receiving error 408 (request timeout) from Google Drive. I have started getting these errors occasionally and they are causing backups to be interrupted. You may wish to edit the 'message', I wasn't sure what to put there, I just copied the code from another HTTP error listed there.