### PR TITLE
When prefetching chunks don't stop on a chunk that may not be needed

### DIFF
--- a/src/duplicacy_chunkdownloader.go
+++ b/src/duplicacy_chunkdownloader.go
@@ -220,7 +220,7 @@ func (downloader *ChunkDownloader) WaitForChunk(chunkIndex int) (chunk *Chunk) {
 		}
 		task := &downloader.taskList[i]
 		if !task.needed {
-			break
+			continue
 		}
 
 		if !task.isDownloading {


### PR DESCRIPTION
When prefetching chunks to be downloaded during a restore operation, the current strategy is to stop at the first chunk that may not be needed, which may be too conservative.  This simple change is to keep looking at other chunks in order to prefetch enough chunks to keep the download pipeline busy.