### PR TITLE
Support downloading files from a custom public URL pointing to b2.

### DIFF
--- a/src/duplicacy_b2client.go
+++ b/src/duplicacy_b2client.go
@@ -54,11 +54,12 @@ type B2Client struct {
 	TestMode bool
 }
 
-func NewB2Client(applicationKeyID string, applicationKey string) *B2Client {
+func NewB2Client(applicationKeyID string, applicationKey string, publicURL string) *B2Client {
 	client := &B2Client{
 		HTTPClient:       http.DefaultClient,
 		ApplicationKeyID: applicationKeyID,
 		ApplicationKey:   applicationKey,
+		DownloadURL:      publicURL,
 	}
 	return client
 }
@@ -232,7 +233,10 @@ func (client *B2Client) AuthorizeAccount() (err error) {
 
 	client.AuthorizationToken = output.AuthorizationToken
 	client.APIURL = output.APIURL
-	client.DownloadURL = output.DownloadURL
+
+	if len(client.DownloadURL) == 0 {
+		client.DownloadURL = output.DownloadURL
+	}
 
 	return nil
 }

--- a/src/duplicacy_b2client_test.go
+++ b/src/duplicacy_b2client_test.go
@@ -37,7 +37,7 @@ func createB2ClientForTest(t *testing.T) (*B2Client, string) {
 		return nil, ""
 	}
 
-	return NewB2Client(b2["account"], b2["key"]), b2["bucket"]
+	return NewB2Client(b2["account"], b2["key"], ""), b2["bucket"]
 
 }
 

--- a/src/duplicacy_b2storage.go
+++ b/src/duplicacy_b2storage.go
@@ -15,12 +15,12 @@ type B2Storage struct {
 }
 
 // CreateB2Storage creates a B2 storage object.
-func CreateB2Storage(accountID string, applicationKey string, bucket string, threads int) (storage *B2Storage, err error) {
+func CreateB2Storage(accountID string, applicationKey string, bucket string, threads int, publicURL string) (storage *B2Storage, err error) {
 
 	var clients []*B2Client
 
 	for i := 0; i < threads; i++ {
-		client := NewB2Client(accountID, applicationKey)
+		client := NewB2Client(accountID, applicationKey, publicURL)
 
 		err = client.AuthorizeAccount()
 		if err != nil {

--- a/src/duplicacy_storage.go
+++ b/src/duplicacy_storage.go
@@ -530,7 +530,7 @@ func CreateStorage(preference Preference, resetPassword bool, threads int) (stor
 		accountID := GetPassword(preference, "b2_id", "Enter Backblaze Account ID:", true, resetPassword)
 		applicationKey := GetPassword(preference, "b2_key", "Enter Backblaze Application Key:", true, resetPassword)
 
-		b2Storage, err := CreateB2Storage(accountID, applicationKey, bucket, threads)
+		b2Storage, err := CreateB2Storage(accountID, applicationKey, bucket, threads, preference.Keys["b2_public_url"])
 		if err != nil {
 			LOG_ERROR("STORAGE_CREATE", "Failed to load the Backblaze B2 storage at %s: %v", storageURL, err)
 			return nil

--- a/src/duplicacy_storage_test.go
+++ b/src/duplicacy_storage_test.go
@@ -107,7 +107,7 @@ func loadStorage(localStoragePath string, threads int) (Storage, error) {
 		storage.SetDefaultNestingLevels([]int{2, 3}, 2)
 		return storage, err
 	} else if testStorageName == "b2" {
-		storage, err := CreateB2Storage(config["account"], config["key"], config["bucket"], threads)
+		storage, err := CreateB2Storage(config["account"], config["key"], config["bucket"], threads, "")
 		storage.SetDefaultNestingLevels([]int{2, 3}, 2)
 		return storage, err
 	} else if testStorageName == "gcs-s3" {


### PR DESCRIPTION
Normally downloading files from Backblaze incurs download fees. They are low but over time add up. However Backblaze has a partnership with Cloudflare where downloading files hosted at Backblaze through Cloudflare's CDN doesn't incur any costs (https://www.backblaze.com/b2/solutions/content-delivery.html)

This change adds support for a user to specify the address of the b2 bucket hosted through Cloudflare as `duplicacy set -key b2_public_url -value https://foo.example.com` and subsequently any files that need to be downloaded from backblaze use the public url making the download free.

Unfortunately I wasn't able to run the go tests (even with no code modifications) on my machine so I'm not sure if this passes them.