### PR TITLE
Only log changed files when backing up with -hash.

### DIFF
--- a/src/duplicacy_backupmanager.go
+++ b/src/duplicacy_backupmanager.go
@@ -320,7 +320,7 @@ func (manager *BackupManager) Backup(top string, quickMode bool, threads int, ta
 				j++
 			} else if local.Path == remote.Path {
 				local.RemoteEntry = remote
-				if !quickMode && local.IsSameAs(remote) {
+				if quickMode && local.IsSameAs(remote) {
 					local.Hash = remote.Hash
 					local.StartChunk = remote.StartChunk
 					local.StartOffset = remote.StartOffset

--- a/src/duplicacy_entry.go
+++ b/src/duplicacy_entry.go
@@ -37,6 +37,9 @@ type Entry struct {
 	Link string
 	Hash string
 
+	// For local entries this will be the remote entry if there is a matching one.
+	RemoteEntry *Entry
+
 	UID int
 	GID int
 


### PR DESCRIPTION
This fixes the issue described at https://forum.duplicacy.com/t/why-do-hash-backups-show-every-single-file-being-uploaded/1808.

It works by checking if the file actually changed and then adding it to either preservedEntries or the new list changedEntries. The latter is purely used for display purposes. I suspect there is a way to just modify modifiedEntries an uploadedEntries instead but I'm not sure I understand the snapshot format well enough for that.

I'm not entirely happy with adding the RemoteEntry property to Entry but it seemed the easiest way to do this.