### PR TITLE
Improve WebDAV performance

### DIFF
--- a/src/duplicacy_webdavstorage.go
+++ b/src/duplicacy_webdavstorage.go
@@ -128,7 +128,12 @@ func (storage *WebDAVStorage) sendRequest(method string, uri string, depth int, 
 			dataReader = bytes.NewReader(data)
 		} else if method == "PUT" {
 			headers["Content-Type"] = "application/octet-stream"
-			dataReader = CreateRateLimitedReader(data, storage.UploadRateLimit/storage.threads)
+			headers["Content-Length"] = fmt.Sprintf("%d", len(data))
+			if storage.UploadRateLimit <= 0 {
+				dataReader = bytes.NewReader(data)
+			} else {
+				dataReader = CreateRateLimitedReader(data, storage.UploadRateLimit/storage.threads)
+			}
 		} else if method == "MOVE" {
 			headers["Destination"] = storage.createConnectionString(string(data))
 			headers["Content-Type"] = "application/octet-stream"
@@ -169,6 +174,7 @@ func (storage *WebDAVStorage) sendRequest(method string, uri string, depth int, 
 			return nil, nil, errWebDAVMovedPermanently
 		}
 
+		io.Copy(ioutil.Discard, response.Body)
 		response.Body.Close()
 		if response.StatusCode == 404 {
 			// Retry if it is UPLOAD, otherwise return immediately
@@ -351,6 +357,7 @@ func (storage *WebDAVStorage) DeleteFile(threadIndex int, filePath string) (err 
 	if err != nil {
 		return err
 	}
+	io.Copy(ioutil.Discard, readCloser)
 	readCloser.Close()
 	return nil
 }
@@ -361,6 +368,7 @@ func (storage *WebDAVStorage) MoveFile(threadIndex int, from string, to string) 
 	if err != nil {
 		return err
 	}
+	io.Copy(ioutil.Discard, readCloser)
 	readCloser.Close()
 	return nil
 }
@@ -412,6 +420,7 @@ func (storage *WebDAVStorage) CreateDirectory(threadIndex int, dir string) (err 
 		}
 		return err
 	}
+	io.Copy(ioutil.Discard, readCloser)
 	readCloser.Close()
 	return nil
 }
@@ -437,6 +446,7 @@ func (storage *WebDAVStorage) UploadFile(threadIndex int, filePath string, conte
 	if err != nil {
 		return err
 	}
+	io.Copy(ioutil.Discard, readCloser)
 	readCloser.Close()
 	return nil
 }


### PR DESCRIPTION
This PR does two things:

* Add `io.Copy(ioutil.Discard, resp.Body)`, which is needed for proper connection reuse, as described here: https://awmanoj.github.io/tech/2016/12/16/keep-alive-http-requests-in-golang/
* Use a non-rate limited reader for uploading when there is no rate limit set. This ensures that the file is sent in one chunk instead of multiple. Some WebDAV servers don't like chunked transfer, and take longer to process files sent that way.

The current code performs as follows for me:

![duplicacy-chunked](https://user-images.githubusercontent.com/9155798/53660229-a8047400-3c5d-11e9-8382-4df1afa059f5.png)

And with this PR, it looks like this:

![duplicacy-nonchunked](https://user-images.githubusercontent.com/9155798/53660287-cb2f2380-3c5d-11e9-9682-3dd533b7b1d9.png)

Please forgive any stupid mistakes I might have made. This is quite literally my first time doing anything in go.