### PR TITLE
Zero-length and effectively zero-length handling issues

### DIFF
--- a/src/duplicacy_backupmanager.go
+++ b/src/duplicacy_backupmanager.go
@@ -137,6 +137,11 @@ func setEntryContent(entries []*Entry, chunkLengths []int, offset int) {
 			if totalChunkSize+int64(length) == totalFileSize {
 				entries[i].StartChunk = j + 1 + offset
 				entries[i].StartOffset = 0
+				if entries[i].Size == 0 {
+					break // zero-length file at end of chunk, we need to exit inner loop to advance j to the next chunk
+					// otherwise, inner for-loop will assign EndChunk = j + offset (which would be before StartChunk = j + 1 + offset)
+					// this also covers the cases where the zero-length file is associated with a zero-length chunk, so we don't re-assign zero-length chunk to next file.
+				}
 			} else {
 				entries[i].StartChunk = j + offset
 				entries[i].StartOffset = int(totalFileSize - totalChunkSize)
@@ -352,6 +357,11 @@ func (manager *BackupManager) Backup(top string, quickMode bool, threads int, ta
 	deletedChunks := 0
 	for _, entry := range preservedEntries {
 
+		// fix zero-size issues for storage saved by v2.1.2 or earlier (caused error in bundle_or_chunk, and possibly in main branch) JAK
+		//  note that Duplicacy had created an extraneous zero-length chunk and assigned it as the StartChunk of a non-zero-length file.
+		for remoteSnapshot.ChunkLengths[entry.StartChunk] == 0 && entry.Size != 0 {
+			entry.StartChunk++
+		}
 		if entry.StartChunk > last {
 			deletedChunks += entry.StartChunk - last - 1
 		}

--- a/src/duplicacy_backupmanager.go
+++ b/src/duplicacy_backupmanager.go
@@ -309,7 +309,7 @@ func (manager *BackupManager) Backup(top string, quickMode bool, threads int, ta
 
 			local := localSnapshot.Files[i]
 
-			if !local.IsFile() || local.Size == 0 {
+			if !local.IsFile() { // || local.Size == 0 <- process zero-length files so we can count them same as we did on the initial backup.
 				i++
 				continue
 			}
@@ -665,7 +665,7 @@ func (manager *BackupManager) Backup(top string, quickMode bool, threads int, ta
 	if showStatistics {
 
 		LOG_INFO("BACKUP_STATS", "Files: %d total, %s bytes; %d new, %s bytes",
-			len(preservedEntries)+len(uploadedEntries),
+			localSnapshot.NumberOfFiles,
 			PrettyNumber(preservedFileSize+uploadedFileSize),
 			len(uploadedEntries), PrettyNumber(uploadedFileSize))
 

--- a/src/duplicacy_chunkmaker.go
+++ b/src/duplicacy_chunkmaker.go
@@ -152,7 +152,7 @@ func (maker *ChunkMaker) ForEachChunk(reader io.Reader, endOfChunk func(chunk *C
 
 				if err != nil {
 					if err != io.EOF {
-						LOG_ERROR("CHUNK_MAKER", "Failed to read %d bytes: %s", count, err.Error())
+						LOG_ERROR("CHUNK_MAKER", "Failed after read %d bytes: %s", fileSize+int64(count), err.Error())
 						return
 					} else {
 						isEOF = true
@@ -204,7 +204,7 @@ func (maker *ChunkMaker) ForEachChunk(reader io.Reader, endOfChunk func(chunk *C
 			count, err = reader.Read(maker.buffer[start : start+count])
 
 			if err != nil && err != io.EOF {
-				LOG_ERROR("CHUNK_MAKER", "Failed to read %d bytes: %s", count, err.Error())
+				LOG_ERROR("CHUNK_MAKER", "Failed after read %d bytes: %s", fileSize+int64(count), err.Error())
 				return
 			}
 

--- a/src/duplicacy_chunkmaker.go
+++ b/src/duplicacy_chunkmaker.go
@@ -171,9 +171,13 @@ func (maker *ChunkMaker) ForEachChunk(reader io.Reader, endOfChunk func(chunk *C
 				if !ok {
 					endOfChunk(chunk, true)
 					return
-				} else {
-					endOfChunk(chunk, false)
-					startNewChunk()
+				} else { // new file started.
+					// If previous file was an exact multiple of chunk size, the last read returned EOF with zero bytes in the chunk buffer.
+					//   Don't save a zero-length chunk, it can confuse downstream processing! (Also, no need to reset a zero-length chunk.)
+					if chunk.GetLength() > 0 {
+						endOfChunk(chunk, false)
+						startNewChunk()
+					}
 					fileSize = 0
 					fileHasher = maker.config.NewFileHasher()
 					isEOF = false

--- a/src/duplicacy_entry.go
+++ b/src/duplicacy_entry.go
@@ -413,7 +413,9 @@ func (entries ByChunk) Len() int      { return len(entries) }
 func (entries ByChunk) Swap(i, j int) { entries[i], entries[j] = entries[j], entries[i] }
 func (entries ByChunk) Less(i, j int) bool {
 	return entries[i].StartChunk < entries[j].StartChunk ||
-		(entries[i].StartChunk == entries[j].StartChunk && entries[i].StartOffset < entries[j].StartOffset)
+		(entries[i].StartChunk == entries[j].StartChunk && entries[i].StartOffset < entries[j].StartOffset) ||
+		// sort zero-length files correctly
+		(entries[i].StartChunk == entries[j].StartChunk && entries[i].StartOffset == entries[j].StartOffset && entries[i].EndOffset < entries[j].EndOffset)
 }
 
 // This is used to sort FileInfo objects.

--- a/src/duplicacy_filereader.go
+++ b/src/duplicacy_filereader.go
@@ -45,6 +45,7 @@ func (reader *FileReader) NextFile() bool {
 	for reader.CurrentIndex < len(reader.files) {
 
 		reader.CurrentEntry = reader.files[reader.CurrentIndex]
+		// note: reader.CurrentEntry.Size == 0 doesn't work since Size was set to -1 before creating the filereader! (see backupmanager)
 		if !reader.CurrentEntry.IsFile() || reader.CurrentEntry.Size == 0 {
 			reader.CurrentIndex++
 			continue


### PR DESCRIPTION
This PR fixes several issues related to zero-length files. 
1. Most notably fixes Issue #309 "Partially locked files" (fix is in file reader so that the "partially locked" file is treated exactly the same as "fully locked" files; the fix further assumes that the "partially locked" file returns an error upon reading the first few bytes, which has been true in all cases on my Windows 10 system.)
2. Fixes inconsistency in how zero-length files are reported. In v2.1.2, fewer total files are reported on incrementals than on initial backups because full backups count zero-length files whereas incrementals didn't.  Also solves: https://forum.duplicacy.com/t/backup-of-zero-byte-files/1376
3. Fixes a potentially fatal bug in which zero-length chunks are created and then associated with non-zero-length files. See https://github.com/gilbertchen/duplicacy/pull/456#issuecomment-471156048

(Sorry, have been sitting on this branch for a month but hadn't had time to organize this description.)
