### PR TITLE
Signal backup status in an env variable

### DIFF
--- a/src/duplicacy_backupmanager.go
+++ b/src/duplicacy_backupmanager.go
@@ -169,6 +169,8 @@ func (manager *BackupManager) Backup(top string, quickMode bool, threads int, ta
 	top, err = filepath.Abs(top)
 	if err != nil {
 		LOG_ERROR("REPOSITORY_ERR", "Failed to obtain the absolute path of the repository: %v", err)
+		os.Setenv("DUPLICACY_BACKUP_STATUS", "ERROR")
+		os.Setenv("DUPLICACY_BACKUP_ERROR", "REPOSITORY_ERR")
 		return false
 	}
 
@@ -191,6 +193,8 @@ func (manager *BackupManager) Backup(top string, quickMode bool, threads int, ta
 	localSnapshot, skippedDirectories, skippedFiles, err := CreateSnapshotFromDirectory(manager.snapshotID, shadowTop, manager.nobackupFile)
 	if err != nil {
 		LOG_ERROR("SNAPSHOT_LIST", "Failed to list the directory %s: %v", top, err)
+		os.Setenv("DUPLICACY_BACKUP_STATUS", "ERROR")
+		os.Setenv("DUPLICACY_BACKUP_ERROR", "SNAPSHOT_LIST")
 		return false
 	}
 
@@ -585,6 +589,8 @@ func (manager *BackupManager) Backup(top string, quickMode bool, threads int, ta
 	if err != nil {
 		RunAtError = func() {} // Don't save the incomplete snapshot
 		LOG_ERROR("SNAPSHOT_CHECK", "The snapshot contains an error: %v", err)
+		os.Setenv("DUPLICACY_BACKUP_STATUS", "ERROR")
+		os.Setenv("DUPLICACY_BACKUP_ERROR", "SNAPSHOT_CHECK")
 		return false
 	}
 
@@ -596,6 +602,8 @@ func (manager *BackupManager) Backup(top string, quickMode bool, threads int, ta
 
 	if _, found := os.LookupEnv("DUPLICACY_FAIL_SNAPSHOT"); found {
 		LOG_ERROR("SNAPSHOT_FAIL", "Artificially fail the backup for testing purposes")
+		os.Setenv("DUPLICACY_BACKUP_STATUS", "ERROR")
+		os.Setenv("DUPLICACY_BACKUP_ERROR", "SNAPSHOT_FAIL")
 		return false
 	}
 
@@ -713,6 +721,8 @@ func (manager *BackupManager) Backup(top string, quickMode bool, threads int, ta
 		skipped += " not included due to access errors"
 		LOG_WARN("BACKUP_SKIPPED", skipped)
 	}
+
+	os.Setenv("DUPLICACY_BACKUP_STATUS", "SUCCESS")
 
 	return true
 }


### PR DESCRIPTION
Write `SUCCESS` or `ERROR` to the OS Environment Variable `DUPLICACY_BACKUP_STATUS`.
In case of an `ERROR`, write the cause into `DUPLICACY_BACKUP_ERROR` 