### PR TITLE
Bugfix [B2]: Add BucketName to API call in FindBucket function

### DIFF
--- a/src/duplicacy_b2client.go
+++ b/src/duplicacy_b2client.go
@@ -344,6 +344,7 @@ func (client *B2Client) FindBucket(bucketName string) (err error) {
 
 	input := make(map[string]string)
 	input["accountId"] = client.AccountID
+	input["bucketName"] = bucketName
 
 	url := client.getAPIURL() + "/b2api/v1/b2_list_buckets"
 


### PR DESCRIPTION
### Background ###
Since about 12 hours I am getting a lot of failed backup notifications. 
Errors look like this:
```
2019-06-28 11:11:08.174 TRACE BACKBLAZE_CALL [0] URL request 'POST https://api002.backblazeb2.com/b2api/v1/b2_list_buckets' returned 401
2019-06-28 11:11:45.914 TRACE BACKBLAZE_CALL [0] URL request 'POST https://api002.backblazeb2.com/b2api/v1/b2_list_buckets' returned 401
2019-06-28 11:11:46.826 TRACE BACKBLAZE_CALL [0] URL request 'POST https://api002.backblazeb2.com/b2api/v1/b2_list_buckets' returned 401
2019-06-28 11:11:46.826 ERROR STORAGE_CREATE Failed to load the Backblaze B2 storage at b2://fsg-cloud: URL request 'https://api002.backblazeb2.com/b2api/v1/b2_list_buckets' returned 401
```

The root cause seems to be a backblaze API change dated Sep. 13, 2018 in the ```b2_list_buckets```  function.
Application Keys restricted to one bucket must include the name of the bucket they want to use in API calls to ```b2_list_buckets```
Reference: https://www.backblaze.com/b2/docs/b2_list_buckets.html

### Changes ###
Adding the bucketName to the API call