### PR TITLE
Added identities-only global flag, similar to ssh_config's IdentitiesOnly

### DIFF
--- a/duplicacy/duplicacy_main.go
+++ b/duplicacy/duplicacy_main.go
@@ -24,7 +24,7 @@ import (
 
 	"io/ioutil"
 
-	"github.com/gilbertchen/duplicacy/src"
+	duplicacy "github.com/gilbertchen/duplicacy/src"
 )
 
 const (
@@ -160,6 +160,7 @@ func setGlobalOptions(context *cli.Context) {
 	}
 
 	duplicacy.RunInBackground = context.GlobalBool("background")
+	duplicacy.IdentitiesOnly = context.GlobalBool("identities-only")
 }
 
 func runScript(context *cli.Context, storageName string, phase string) bool {
@@ -784,8 +785,6 @@ func restoreRepository(context *cli.Context) {
 
 		patterns = append(patterns, pattern)
 
-	
-
 	}
 	patterns = duplicacy.ProcessFilterLines(patterns, make([]string, 0))
 
@@ -1297,7 +1296,7 @@ func benchmark(context *cli.Context) {
 	if storage == nil {
 		return
 	}
-	duplicacy.Benchmark(repository, storage, int64(fileSize) * 1024 * 1024, chunkSize * 1024 * 1024, chunkCount, uploadThreads, downloadThreads)
+	duplicacy.Benchmark(repository, storage, int64(fileSize)*1024*1024, chunkSize*1024*1024, chunkCount, uploadThreads, downloadThreads)
 }
 
 func main() {
@@ -1964,6 +1963,10 @@ func main() {
 		cli.BoolFlag{
 			Name:  "background",
 			Usage: "read passwords, tokens, or keys only from keychain/keyring or env",
+		},
+		cli.BoolFlag{
+			Name:  "identities-only",
+			Usage: "use only identities explicitly configured",
 		},
 		cli.StringFlag{
 			Name:     "profile",

--- a/src/duplicacy_storage.go
+++ b/src/duplicacy_storage.go
@@ -318,7 +318,7 @@ func CreateStorage(preference Preference, resetPassword bool, threads int) (stor
 			signers := []ssh.Signer{}
 
 			agentSock := os.Getenv("SSH_AUTH_SOCK")
-			if agentSock != "" {
+			if agentSock != "" && !IdentitiesOnly {
 				connection, err := net.Dial("unix", agentSock)
 				// TODO:  looks like we need to close the connection
 				if err == nil {

--- a/src/duplicacy_utils.go
+++ b/src/duplicacy_utils.go
@@ -20,7 +20,7 @@ import (
 )
 
 var RunInBackground bool = false
-var IdentitiesOnly bool = true
+var IdentitiesOnly bool = false
 
 type RateLimitedReader struct {
 	Content   []byte

--- a/src/duplicacy_utils.go
+++ b/src/duplicacy_utils.go
@@ -20,6 +20,7 @@ import (
 )
 
 var RunInBackground bool = false
+var IdentitiesOnly bool = true
 
 type RateLimitedReader struct {
 	Content   []byte
@@ -55,7 +56,7 @@ func IsEmptyFilter(pattern string) bool {
 }
 
 func IsUnspecifiedFilter(pattern string) bool {
-	if pattern[0] != '+' && pattern[0] != '-' && !strings.HasPrefix(pattern, "i:") && !strings.HasPrefix(pattern, "e:")  {
+	if pattern[0] != '+' && pattern[0] != '-' && !strings.HasPrefix(pattern, "i:") && !strings.HasPrefix(pattern, "e:") {
 		return true
 	} else {
 		return false


### PR DESCRIPTION
It prevents the usage of ssh-agent for ssh authentication possibly causing the server to disconnect with "Too many authentication failures".
Random styling "fixes" courtesy of Visual studio code... If these present an issue ill fix them by hand.