### PR TITLE
Call ReadAll() on the body io.ReadCloser to allow the http keepalive connection to be reused.

### DIFF
--- a/src/duplicacy_dropboxstorage.go
+++ b/src/duplicacy_dropboxstorage.go
@@ -6,6 +6,7 @@ package duplicacy
 
 import (
 	"fmt"
+	"io/ioutil"
 	"strings"
 
 	"github.com/gilbertchen/go-dropbox"
@@ -199,6 +200,7 @@ func (storage *DropboxStorage) DownloadFile(threadIndex int, filePath string, ch
 	}
 
 	defer output.Body.Close()
+	defer ioutil.ReadAll(output.Body)
 
 	_, err = RateLimitedCopy(chunk, output.Body, storage.DownloadRateLimit/len(storage.clients))
 	return err


### PR DESCRIPTION
This should improve performance on file downloads.