### PR TITLE
Call Authenticate() before using Swift storage

### DIFF
--- a/src/duplicacy_swiftstorage.go
+++ b/src/duplicacy_swiftstorage.go
@@ -129,6 +129,11 @@ func CreateSwiftStorage(storageURL string, key string, threads int) (storage *Sw
 		TrustId:        arguments["trust_id"],
 	}
 
+	err = connection.Authenticate()
+	if err != nil {
+		return nil, err
+	}
+
 	_, _, err = connection.Container(container)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Failing to call Authenticate() before using the swift connection will
cause a panic in recent versions of the swift library.