### PR TITLE
Support GCD impersonation via modified service account file

### DIFF
--- a/src/duplicacy_gcdstorage.go
+++ b/src/duplicacy_gcdstorage.go
@@ -41,6 +41,7 @@ type GCDStorage struct {
 	backoffs    []int // desired backoff time in seconds for each thread
 	attempts    []int // number of failed attempts since last success for each thread
 	driveID     string // the ID of the shared drive or 'root' (GCDUserDrive) if the user's drive
+	spaces      string // 'appDataFolder' if scope is drive.appdata; 'drive' otherwise
 
 	createDirectoryLock sync.Mutex
 	isConnected         bool
@@ -199,7 +200,7 @@ func (storage *GCDStorage) listFiles(threadIndex int, parentID string, listFiles
 		var err error
 
 		for {
-			q := storage.service.Files.List().Q(query).Fields("nextPageToken", "files(name, mimeType, id, size)").PageToken(startToken).PageSize(maxCount)
+			q := storage.service.Files.List().Q(query).Fields("nextPageToken", "files(name, mimeType, id, size)").PageToken(startToken).PageSize(maxCount).Spaces(storage.spaces)
 			if storage.driveID != GCDUserDrive {
 				q = q.DriveId(storage.driveID).IncludeItemsFromAllDrives(true).Corpora("drive").SupportsAllDrives(true)
 			}
@@ -231,7 +232,7 @@ func (storage *GCDStorage) listByName(threadIndex int, parentID string, name str
 
 	for {
 		query := "name = '" + name + "' and '" + parentID + "' in parents and trashed = false "
-		q := storage.service.Files.List().Q(query).Fields("files(name, mimeType, id, size)")
+		q := storage.service.Files.List().Q(query).Fields("files(name, mimeType, id, size)").Spaces(storage.spaces)
 		if storage.driveID != GCDUserDrive {
 			q = q.DriveId(storage.driveID).IncludeItemsFromAllDrives(true).Corpora("drive").SupportsAllDrives(true)
 		}
@@ -344,11 +345,23 @@ func CreateGCDStorage(tokenFile string, driveID string, storagePath string, thre
 
 	var tokenSource oauth2.TokenSource
 
+	scope := drive.DriveScope
+
 	if isServiceAccount {
-		config, err := google.JWTConfigFromJSON(description, drive.DriveScope)
+
+		if newScope, ok := object["scope"]; ok {
+			scope = newScope.(string)
+		}
+
+		config, err := google.JWTConfigFromJSON(description, scope)
 		if err != nil {
 			return nil, err
 		}
+
+		if subject, ok := object["subject"]; ok {
+		    config.Subject = subject.(string)
+		}
+
 		tokenSource = config.TokenSource(ctx)
 	} else {
 		gcdConfig := &GCDConfig{}
@@ -398,6 +411,7 @@ func CreateGCDStorage(tokenFile string, driveID string, storagePath string, thre
 		backoffs:        make([]int, threads),
 		attempts:        make([]int, threads),
 		driveID:         driveID,
+		spaces:          "drive",
 	}
 
 	for i := range storage.backoffs {
@@ -405,7 +419,14 @@ func CreateGCDStorage(tokenFile string, driveID string, storagePath string, thre
 		storage.attempts[i] = 0
 	}
 
-	storage.savePathID("", driveID)
+
+	if scope == drive.DriveAppdataScope {
+		storage.spaces = "appDataFolder"
+		storage.savePathID("", "appDataFolder")
+	} else {
+		storage.savePathID("", driveID)
+	}
+
 	storagePathID, err := storage.getIDFromPath(0, storagePath, true)
 	if err != nil {
 		return nil, err

--- a/src/duplicacy_storage_test.go
+++ b/src/duplicacy_storage_test.go
@@ -142,6 +142,10 @@ func loadStorage(localStoragePath string, threads int) (Storage, error) {
 		storage, err := CreateGCDStorage(config["token_file"], config["drive"], config["storage_path"], threads)
 		storage.SetDefaultNestingLevels([]int{2, 3}, 2)
 		return storage, err
+	} else if testStorageName == "gcd-impersonate" {
+		storage, err := CreateGCDStorage(config["token_file"], config["drive"], config["storage_path"], threads)
+		storage.SetDefaultNestingLevels([]int{2, 3}, 2)
+		return storage, err
 	} else if testStorageName == "one" {
 		storage, err := CreateOneDriveStorage(config["token_file"], false, config["storage_path"], threads)
 		storage.SetDefaultNestingLevels([]int{2, 3}, 2)


### PR DESCRIPTION
This change allows a service account json file created by a domain admin to be used to access Google Drive for another user under the same domain.

The service account json file must be manually edited to add these two lines:

```
  "subject": "user@domain.com",
  "scope": "https://www.googleapis.com/auth/drive.file",
```

The scope can be `drive`, `drive.file`, or `drive.appdata`.  For `drive.appdata`, the backups will be stored under the special app data folder that isn't usually visible in the Google Drive.  It can only be accessed programmatically with the Spaces set `appDataFolder` (the default Spaces is `drive`) with the root id of `appDataFolder`.

See discussion here: https://forum.duplicacy.com/t/google-drive-drive-appdata-scope-service-account-impersonate/4462