### PR TITLE
Implement backing up of block devices on Unix

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -86,6 +86,10 @@
   name = "golang.org/x/net"
 
 [[constraint]]
+  branch = "master"
+  name = "golang.org/x/sys"
+
+[[constraint]]
   name = "golang.org/x/oauth2"
   revision = "bf48bf16ab8d622ce64ec6ce98d2c98f916b6303"
 

--- a/src/duplicacy_backupmanager_test.go
+++ b/src/duplicacy_backupmanager_test.go
@@ -253,7 +253,7 @@ func TestBackupManager(t *testing.T) {
 	time.Sleep(time.Duration(delay) * time.Second)
 
 	SetDuplicacyPreferencePath(testDir + "/repository1/.duplicacy")
-	backupManager := CreateBackupManager("host1", storage, testDir, password, "", "", false)
+	backupManager := CreateBackupManager("host1", storage, testDir, password, "", "", false, false)
 	backupManager.SetupSnapshotCache("default")
 
 	SetDuplicacyPreferencePath(testDir + "/repository1/.duplicacy")
@@ -529,7 +529,7 @@ func TestPersistRestore(t *testing.T) {
 
 	// do unencrypted backup
 	SetDuplicacyPreferencePath(testDir + "/repository1/.duplicacy")
-	unencBackupManager := CreateBackupManager("host1", unencStorage, testDir, "", "", "", false)
+	unencBackupManager := CreateBackupManager("host1", unencStorage, testDir, "", "", "", false, false)
 	unencBackupManager.SetupSnapshotCache("default")
 
 	SetDuplicacyPreferencePath(testDir + "/repository1/.duplicacy")
@@ -539,7 +539,7 @@ func TestPersistRestore(t *testing.T) {
 
 	// do encrypted backup
 	SetDuplicacyPreferencePath(testDir + "/repository1/.duplicacy")
-	encBackupManager := CreateBackupManager("host1", storage, testDir, password, "", "", false)
+	encBackupManager := CreateBackupManager("host1", storage, testDir, password, "", "", false, false)
 	encBackupManager.SetupSnapshotCache("default")
 
 	SetDuplicacyPreferencePath(testDir + "/repository1/.duplicacy")

--- a/src/duplicacy_entry_test.go
+++ b/src/duplicacy_entry_test.go
@@ -177,7 +177,7 @@ func TestEntryList(t *testing.T) {
 		directory := directories[len(directories)-1]
 		directories = directories[:len(directories)-1]
 		entries = append(entries, directory)
-		subdirectories, _, err := ListEntries(testDir, directory.Path, &entries, nil, "", false, false)
+		subdirectories, _, err := ListEntries(testDir, directory.Path, &entries, nil, "", false, false, false)
 		if err != nil {
 			t.Errorf("ListEntries(%s, %s) returned an error: %s", testDir, directory.Path, err)
 		}
@@ -279,7 +279,7 @@ func TestEntryExcludeByAttribute(t *testing.T) {
 			directory := directories[len(directories)-1]
 			directories = directories[:len(directories)-1]
 			entries = append(entries, directory)
-			subdirectories, _, err := ListEntries(testDir, directory.Path, &entries, nil, "", false, excludeByAttribute)
+			subdirectories, _, err := ListEntries(testDir, directory.Path, &entries, nil, "", false, excludeByAttribute, false)
 			if err != nil {
 				t.Errorf("ListEntries(%s, %s) returned an error: %s", testDir, directory.Path, err)
 			}

--- a/src/duplicacy_preference.go
+++ b/src/duplicacy_preference.go
@@ -27,6 +27,7 @@ type Preference struct {
 	Keys              map[string]string `json:"keys"`
 	FiltersFile       string            `json:"filters"`
 	ExcludeByAttribute bool             `json:"exclude_by_attribute"`
+	ReadBlockDevices  bool              `json:"read_block_devices"`
 }
 
 var preferencePath string

--- a/src/duplicacy_snapshot.go
+++ b/src/duplicacy_snapshot.go
@@ -58,7 +58,7 @@ func CreateEmptySnapshot(id string) (snapshto *Snapshot) {
 
 // CreateSnapshotFromDirectory creates a snapshot from the local directory 'top'.  Only 'Files'
 // will be constructed, while 'ChunkHashes' and 'ChunkLengths' can only be populated after uploading.
-func CreateSnapshotFromDirectory(id string, top string, nobackupFile string, filtersFile string, excludeByAttribute bool) (snapshot *Snapshot, skippedDirectories []string,
+func CreateSnapshotFromDirectory(id string, top string, nobackupFile string, filtersFile string, excludeByAttribute bool, readBlockDevices bool) (snapshot *Snapshot, skippedDirectories []string,
 	skippedFiles []string, err error) {
 
 	snapshot = &Snapshot{
@@ -89,7 +89,7 @@ func CreateSnapshotFromDirectory(id string, top string, nobackupFile string, fil
 		directory := directories[len(directories)-1]
 		directories = directories[:len(directories)-1]
 		snapshot.Files = append(snapshot.Files, directory)
-		subdirectories, skipped, err := ListEntries(top, directory.Path, &snapshot.Files, patterns, nobackupFile, snapshot.discardAttributes, excludeByAttribute)
+		subdirectories, skipped, err := ListEntries(top, directory.Path, &snapshot.Files, patterns, nobackupFile, snapshot.discardAttributes, excludeByAttribute, readBlockDevices)
 		if err != nil {
 			if directory.Path == "" {
 				LOG_ERROR("LIST_FAILURE", "Failed to list the repository root: %v", err)

--- a/src/duplicacy_snapshotmanager.go
+++ b/src/duplicacy_snapshotmanager.go
@@ -1469,7 +1469,7 @@ func (manager *SnapshotManager) PrintFile(snapshotID string, revision int, path 
 
 // Diff compares two snapshots, or two revision of a file if the file argument is given.
 func (manager *SnapshotManager) Diff(top string, snapshotID string, revisions []int,
-	filePath string, compareByHash bool, nobackupFile string, filtersFile string, excludeByAttribute bool) bool {
+	filePath string, compareByHash bool, nobackupFile string, filtersFile string, excludeByAttribute bool, readBlockDevices bool) bool {
 
 	LOG_DEBUG("DIFF_PARAMETERS", "top: %s, id: %s, revision: %v, path: %s, compareByHash: %t",
 		top, snapshotID, revisions, filePath, compareByHash)
@@ -1482,7 +1482,7 @@ func (manager *SnapshotManager) Diff(top string, snapshotID string, revisions []
 	if len(revisions) <= 1 {
 		// Only scan the repository if filePath is not provided
 		if len(filePath) == 0 {
-			rightSnapshot, _, _, err = CreateSnapshotFromDirectory(snapshotID, top, nobackupFile, filtersFile, excludeByAttribute)
+			rightSnapshot, _, _, err = CreateSnapshotFromDirectory(snapshotID, top, nobackupFile, filtersFile, excludeByAttribute, readBlockDevices)
 			if err != nil {
 				LOG_ERROR("SNAPSHOT_LIST", "Failed to list the directory %s: %v", top, err)
 				return false


### PR DESCRIPTION
This commit adds the -read-block-devices option, which when enabled, treats block devices as regular files and stores them in the snapshot as such. Restore also works as expected if the -overwrite flag is passed.

Borg has a similar flag `--read-special` that will treat all special files (block devices, character devices, named FIFOs) as regular files and back them up; however, they wouldn't work for Duplicacy because it needs to know the size of the file beforehand. There's also not much point to backing up a character device or FIFO, so this feature only works with block devices.

Tested on Arch Linux. I've implemented this feature to address #345 and so that I could directly back up my LVM volumes into my repository. Cheers!