### PR TITLE
Dropbox storage retrying with generic RetryableStorage interface

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -32,6 +32,12 @@
   version = "v1.0.0"
 
 [[projects]]
+  name = "github.com/cenkalti/backoff"
+  packages = ["."]
+  revision = "5267b6dd4d2666b980a911bf235efa276222cbe2"
+  version = "v2.2.1"
+
+[[projects]]
   name = "github.com/dgrijalva/jwt-go"
   packages = ["."]
   revision = "06ea1031745cb8b3dab3f6a236daf2b0aa468b7e"
@@ -271,6 +277,41 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e46f7c2dac527af6d5a0d47f1444421a6738d28252eb5d6084fc1c65f2b41bd8"
+  input-imports = [
+    "cloud.google.com/go/storage",
+    "github.com/aryann/difflib",
+    "github.com/aws/aws-sdk-go/aws",
+    "github.com/aws/aws-sdk-go/aws/awserr",
+    "github.com/aws/aws-sdk-go/aws/credentials",
+    "github.com/aws/aws-sdk-go/aws/session",
+    "github.com/aws/aws-sdk-go/service/s3",
+    "github.com/bkaradzic/go-lz4",
+    "github.com/cenkalti/backoff",
+    "github.com/gilbertchen/azure-sdk-for-go/storage",
+    "github.com/gilbertchen/cli",
+    "github.com/gilbertchen/go-dropbox",
+    "github.com/gilbertchen/go-ole",
+    "github.com/gilbertchen/goamz/aws",
+    "github.com/gilbertchen/goamz/s3",
+    "github.com/gilbertchen/gopass",
+    "github.com/gilbertchen/keyring",
+    "github.com/gilbertchen/xattr",
+    "github.com/klauspost/reedsolomon",
+    "github.com/minio/blake2b-simd",
+    "github.com/minio/highwayhash",
+    "github.com/ncw/swift",
+    "github.com/pkg/sftp",
+    "github.com/pkg/xattr",
+    "golang.org/x/crypto/pbkdf2",
+    "golang.org/x/crypto/ssh",
+    "golang.org/x/crypto/ssh/agent",
+    "golang.org/x/net/context",
+    "golang.org/x/oauth2",
+    "golang.org/x/oauth2/google",
+    "google.golang.org/api/drive/v3",
+    "google.golang.org/api/googleapi",
+    "google.golang.org/api/iterator",
+    "google.golang.org/api/option",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -96,3 +96,7 @@
 [[constraint]]
   name = "google.golang.org/grpc"
   version = "1.28.0"
+
+[[constraint]]
+  name = "github.com/cenkalti/backoff"
+  version = "2.2.1"


### PR DESCRIPTION
**Retries implemented for Dropbox `UploadFile()` and `DeleteFile()`**

Also standardizes an interface to configure retrying of storage operations for other providers. I have work-in-progress code to submit that converts the other storage providers to the generic `RetryableStorage` interface, but I didn't want to bloat this PR. I can open a second PR before this is merged, if you'd like.

The test code attempts to exceed rate limits for any `RetryableStorage` by firing off 50 concurrent `UploadFile()` operations, then waiting for all to succeed. This level of concurrency may need to be increased to trigger rate limiting on any excessively generous storage providers.

Adds a dependency on github.com/cenkalti/backoff: used by `RetryableStorage` implementation to provide exponential backoff for storage operation retries.

A version change in `dep` on my machine caused the formatting of `Gopkg.lock` to change significantly. I manually reformatted so that only the non-whitespace changes are part of this commit (to keep the PR shorter).

Before merging, I'd argue that `dep ensure` should be run with the latest or project-adopted version of `dep` so that my manual formatting is reverted to `dep` default behavior.
