### PR TITLE
Add support for AWS STS Tokens in S3 Backend

### DIFF
--- a/src/duplicacy_s3storage.go
+++ b/src/duplicacy_s3storage.go
@@ -33,8 +33,13 @@ type S3Storage struct {
 func CreateS3Storage(regionName string, endpoint string, bucketName string, storageDir string,
 	accessKey string, secretKey string, threads int,
 	isSSLSupported bool, isMinioCompatible bool) (storage *S3Storage, err error) {
+	return CreateS3StorageWithToken(regionName, endpoint, bucketName, storageDir, accessKey, secretKey, "", threads, isSSLSupported, isMinioCompatible)
+}
 
-	token := ""
+// CreatesS3StorageWithToken create an amazon s3 storage object using an optional security token.
+func CreateS3StorageWithToken(regionName string, endpoint string, bucketName string, storageDir string,
+	accessKey string, secretKey string, token string, threads int,
+	isSSLSupported bool, isMinioCompatible bool) (storage *S3Storage, err error) {
 
 	auth := credentials.NewStaticCredentials(accessKey, secretKey, token)
 

--- a/src/duplicacy_storage.go
+++ b/src/duplicacy_storage.go
@@ -455,7 +455,7 @@ func CreateStorage(preference Preference, resetPassword bool, threads int) (stor
 			SavePassword(preference, "ssh_password", password)
 		}
 		return sftpStorage
-	} else if matched[1] == "s3" || matched[1] == "s3c" || matched[1] == "minio" || matched[1] == "minios" {
+	} else if matched[1] == "s3" || matched[1] == "s3c" || matched[1] == "minio" || matched[1] == "minios" || matched[1] == "s3-token" {
 
 		// urlRegex := regexp.MustCompile(`^(\w+)://([\w\-]+@)?([^/]+)(/(.+))?`)
 
@@ -492,7 +492,12 @@ func CreateStorage(preference Preference, resetPassword bool, threads int) (stor
 		} else {
 			isMinioCompatible := (matched[1] == "minio" || matched[1] == "minios")
 			isSSLSupported := (matched[1] == "s3" || matched[1] == "minios")
-			storage, err = CreateS3Storage(region, endpoint, bucket, storageDir, accessKey, secretKey, threads, isSSLSupported, isMinioCompatible)
+			if matched[1] == "s3-token" {
+				token := GetPassword(preference, "s3_token", "Enter S3 Token (Optional):", true, resetPassword)
+				storage, err = CreateS3StorageWithToken(region, endpoint, bucket, storageDir, accessKey, secretKey, token, threads, isSSLSupported, isMinioCompatible)
+			} else {
+				storage, err = CreateS3Storage(region, endpoint, bucket, storageDir, accessKey, secretKey, threads, isSSLSupported, isMinioCompatible)
+			}
 			if err != nil {
 				LOG_ERROR("STORAGE_CREATE", "Failed to load the S3 storage at %s: %v", storageURL, err)
 				return nil


### PR DESCRIPTION
This PR adds support temporary AWS Credentials, issued by calls to `sts:assumeRole` [1].

This feature was already requested a long time ago in the Duplicacy Forum [2].

It adds a new backend variant `s3-token://` in order to be compatible with existing use cases.

If this is desired to be merged I'd be happy to contribute the necessary adjustments to the docs aswell.


[[1] AWS STS Assume Role Docs](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html)
[[2] Duplicacy Forum: S3 Backend - Support for AWS_SESSION_TOKEN (STS)](https://forum.duplicacy.com/t/s3-backend-support-for-aws-session-token-sts/1426)