### PR TITLE
Live backup preview (mount)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
+	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/jmespath/go-jmespath v0.3.0 // indirect
 	github.com/klauspost/cpuid v1.3.1 // indirect
 	github.com/kr/fs v0.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/spacemonkeygo/monkit/v3 v3.0.17 // indirect
 	github.com/vaughan0/go-ini v0.0.0-20130923145212-a98ad7ee00ec // indirect
 	github.com/vivint/infectious v0.0.0-20200605153912-25a574ae18a3 // indirect
+	github.com/winfsp/cgofuse v1.5.0 // indirect
 	github.com/zeebo/errs v1.3.0 // indirect
 	go.opencensus.io v0.22.3 // indirect
 	golang.org/x/mod v0.4.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -126,6 +126,8 @@ github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:Fecb
 github.com/grpc-ecosystem/grpc-gateway v1.5.0/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
+github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20210905161508-09a460cdf81d/go.mod h1:aYm2/VgdVmcIU8iMfdMvDMsRAQjcfZSKFby6HOFvi/w=
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=

--- a/go.sum
+++ b/go.sum
@@ -248,6 +248,8 @@ github.com/vivint/infectious v0.0.0-20200605153912-25a574ae18a3 h1:zMsHhfK9+Wdl1
 github.com/vivint/infectious v0.0.0-20200605153912-25a574ae18a3/go.mod h1:R0Gbuw7ElaGSLOZUSwBm/GgVwMd30jWxBDdAyMOeTuc=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
+github.com/winfsp/cgofuse v1.5.0 h1:MsBP7Mi/LiJf/7/F3O/7HjjR009ds6KCdqXzKpZSWxI=
+github.com/winfsp/cgofuse v1.5.0/go.mod h1:h3awhoUOcn2VYVKCwDaYxSLlZwnyK+A8KaDoLUp2lbU=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=

--- a/src/duplicacy_backupmanager_test.go
+++ b/src/duplicacy_backupmanager_test.go
@@ -1,6 +1,7 @@
 // Copyright (c) Acrosync LLC. All rights reserved.
 // Free for personal use and commercial trial
 // Commercial use requires per-user licenses available from https://duplicacy.com
+// +build !windows
 
 package duplicacy
 

--- a/src/duplicacy_entry_notwin_test.go
+++ b/src/duplicacy_entry_notwin_test.go
@@ -1,0 +1,131 @@
+// Copyright (c) Acrosync LLC. All rights reserved.
+// Free for personal use and commercial trial
+// Commercial use requires per-user licenses available from https://duplicacy.com
+// +build !windows
+
+package duplicacy
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/gilbertchen/xattr"
+)
+
+// TestEntryExcludeByAttribute tests the excludeByAttribute parameter to the ListEntries function
+func TestEntryExcludeByAttribute(t *testing.T) {
+
+	if !(runtime.GOOS == "darwin" || runtime.GOOS == "linux") {
+		t.Skip("skipping test not darwin or linux")
+	}
+
+	testDir := filepath.Join(os.TempDir(), "duplicacy_test")
+
+	os.RemoveAll(testDir)
+	os.MkdirAll(testDir, 0700)
+
+	// Files or folders named with "exclude" below will have the exclusion attribute set on them
+	// When ListEntries is called with excludeByAttribute true, they should be excluded.
+	DATA := [...]string{
+		"excludefile",
+		"includefile",
+		"excludedir/",
+		"excludedir/file",
+		"includedir/",
+		"includedir/includefile",
+		"includedir/excludefile",
+	}
+
+	for _, file := range DATA {
+		fullPath := filepath.Join(testDir, file)
+		if file[len(file)-1] == '/' {
+			err := os.Mkdir(fullPath, 0700)
+			if err != nil {
+				t.Errorf("Mkdir(%s) returned an error: %s", fullPath, err)
+			}
+			continue
+		}
+
+		err := ioutil.WriteFile(fullPath, []byte(file), 0700)
+		if err != nil {
+			t.Errorf("WriteFile(%s) returned an error: %s", fullPath, err)
+		}
+	}
+
+	for _, file := range DATA {
+		fullPath := filepath.Join(testDir, file)
+		if strings.Contains(file, "exclude") {
+			xattr.Setxattr(fullPath, "com.apple.metadata:com_apple_backup_excludeItem", []byte("com.apple.backupd"))
+		}
+	}
+
+	for _, excludeByAttribute := range [2]bool{true, false} {
+		t.Logf("testing excludeByAttribute: %t", excludeByAttribute)
+		directories := make([]*Entry, 0, 4)
+		directories = append(directories, CreateEntry("", 0, 0, 0))
+
+		entries := make([]*Entry, 0, 4)
+		entryChannel := make(chan *Entry, 1024)
+		entries = append(entries, CreateEntry("", 0, 0, 0))
+
+		for len(directories) > 0 {
+			directory := directories[len(directories)-1]
+			directories = directories[:len(directories)-1]
+			subdirectories, _, err := ListEntries(testDir, directory.Path, nil, "", excludeByAttribute, entryChannel)
+			if err != nil {
+				t.Errorf("ListEntries(%s, %s) returned an error: %s", testDir, directory.Path, err)
+			}
+			directories = append(directories, subdirectories...)
+		}
+
+		close(entryChannel)
+
+		for entry := range entryChannel {
+			entries = append(entries, entry)
+		}
+
+		entries = entries[1:]
+
+		for _, entry := range entries {
+			t.Logf("entry: %s", entry.Path)
+		}
+
+		i := 0
+		for _, file := range DATA {
+			entryFound := false
+			var entry *Entry
+			for _, entry = range entries {
+				if entry.Path == file {
+					entryFound = true
+					break
+				}
+			}
+
+			if excludeByAttribute && strings.Contains(file, "exclude") {
+				if entryFound {
+					t.Errorf("file: %s, expected to be excluded but wasn't. attributes: %v", file, entry.Attributes)
+					i++
+				} else {
+					t.Logf("file: %s, excluded", file)
+				}
+			} else {
+				if entryFound {
+					t.Logf("file: %s, included. attributes: %v", file, entry.Attributes)
+					i++
+				} else {
+					t.Errorf("file: %s, expected to be included but wasn't", file)
+				}
+			}
+		}
+
+	}
+
+	if !t.Failed() {
+		os.RemoveAll(testDir)
+	}
+
+}

--- a/src/duplicacy_entry_test.go
+++ b/src/duplicacy_entry_test.go
@@ -5,19 +5,16 @@
 package duplicacy
 
 import (
+	"bytes"
+	"encoding/json"
 	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sort"
-	"strings"
 	"testing"
-	"bytes"
-	"encoding/json"
 
-	"github.com/gilbertchen/xattr"
-    "github.com/vmihailenco/msgpack"
+	"github.com/vmihailenco/msgpack"
 )
 
 func TestEntrySort(t *testing.T) {
@@ -175,7 +172,7 @@ func TestEntryOrder(t *testing.T) {
 	directories = append(directories, CreateEntry("", 0, 0, 0))
 
 	entries := make([]*Entry, 0, 4)
-    entryChannel := make(chan *Entry, 1024)
+	entryChannel := make(chan *Entry, 1024)
 	entries = append(entries, CreateEntry("", 0, 0, 0))
 
 	for len(directories) > 0 {
@@ -222,120 +219,6 @@ func TestEntryOrder(t *testing.T) {
 		if entries[i].Path != DATA[i] {
 			t.Errorf("entry: %s, expected: %s", entries[i].Path, DATA[i])
 		}
-	}
-
-	if !t.Failed() {
-		os.RemoveAll(testDir)
-	}
-
-}
-
-// TestEntryExcludeByAttribute tests the excludeByAttribute parameter to the ListEntries function
-func TestEntryExcludeByAttribute(t *testing.T) {
-
-	if !(runtime.GOOS == "darwin" || runtime.GOOS == "linux") {
-		t.Skip("skipping test not darwin or linux")
-	}
-
-	testDir := filepath.Join(os.TempDir(), "duplicacy_test")
-
-	os.RemoveAll(testDir)
-	os.MkdirAll(testDir, 0700)
-
-	// Files or folders named with "exclude" below will have the exclusion attribute set on them
-	// When ListEntries is called with excludeByAttribute true, they should be excluded.
-	DATA := [...]string{
-		"excludefile",
-		"includefile",
-		"excludedir/",
-		"excludedir/file",
-		"includedir/",
-		"includedir/includefile",
-		"includedir/excludefile",
-	}
-
-	for _, file := range DATA {
-		fullPath := filepath.Join(testDir, file)
-		if file[len(file)-1] == '/' {
-			err := os.Mkdir(fullPath, 0700)
-			if err != nil {
-				t.Errorf("Mkdir(%s) returned an error: %s", fullPath, err)
-			}
-			continue
-		}
-
-		err := ioutil.WriteFile(fullPath, []byte(file), 0700)
-		if err != nil {
-			t.Errorf("WriteFile(%s) returned an error: %s", fullPath, err)
-		}
-	}
-
-	for _, file := range DATA {
-		fullPath := filepath.Join(testDir, file)
-		if strings.Contains(file, "exclude") {
-			xattr.Setxattr(fullPath, "com.apple.metadata:com_apple_backup_excludeItem", []byte("com.apple.backupd"))
-		}
-	}
-
-	for _, excludeByAttribute := range [2]bool{true, false} {
-		t.Logf("testing excludeByAttribute: %t", excludeByAttribute)
-		directories := make([]*Entry, 0, 4)
-		directories = append(directories, CreateEntry("", 0, 0, 0))
-
-		entries := make([]*Entry, 0, 4)
-		entryChannel := make(chan *Entry, 1024)
-		entries = append(entries, CreateEntry("", 0, 0, 0))
-
-		for len(directories) > 0 {
-			directory := directories[len(directories)-1]
-			directories = directories[:len(directories)-1]
-			subdirectories, _, err := ListEntries(testDir, directory.Path, nil, "", excludeByAttribute, entryChannel)
-			if err != nil {
-				t.Errorf("ListEntries(%s, %s) returned an error: %s", testDir, directory.Path, err)
-			}
-			directories = append(directories, subdirectories...)
-		}
-
-		close(entryChannel)
-
-		for entry := range entryChannel {
-			entries = append(entries, entry)
-		}
-
-		entries = entries[1:]
-
-		for _, entry := range entries {
-			t.Logf("entry: %s", entry.Path)
-		}
-
-		i := 0
-		for _, file := range DATA {
-			entryFound := false
-			var entry *Entry
-			for _, entry = range entries {
-				if entry.Path == file {
-					entryFound = true
-					break
-				}
-			}
-
-			if excludeByAttribute && strings.Contains(file, "exclude") {
-				if entryFound {
-					t.Errorf("file: %s, expected to be excluded but wasn't. attributes: %v", file, entry.Attributes)
-					i++
-				} else {
-					t.Logf("file: %s, excluded", file)
-				}
-			} else {
-				if entryFound {
-					t.Logf("file: %s, included. attributes: %v", file, entry.Attributes)
-					i++
-				} else {
-					t.Errorf("file: %s, expected to be included but wasn't", file)
-				}
-			}
-		}
-
 	}
 
 	if !t.Failed() {

--- a/src/duplicacy_mount.go
+++ b/src/duplicacy_mount.go
@@ -292,9 +292,9 @@ func (self *BackupFS) initRevision(path string) (ret int) {
 		self.manager.SnapshotManager.chunkOperator,
 		func(entry *Entry) bool {
 			if entry.Mode&0o20000000000 == 0o20000000000 {
-				self.makeNode(fmt.Sprintf("%s/%s", root, entry.Path), fuse.S_IFDIR|(entry.Mode&00555), fuse.Timespec{Sec: entry.Time})
+				self.makeNode(fmt.Sprintf("%s/%s", root, entry.Path), fuse.S_IFDIR|(entry.Mode&00777), fuse.Timespec{Sec: entry.Time})
 			} else {
-				node, err := self.makeNode(fmt.Sprintf("%s/%s", root, entry.Path), entry.Mode&00555, fuse.Timespec{Sec: entry.Time})
+				node, err := self.makeNode(fmt.Sprintf("%s/%s", root, entry.Path), entry.Mode, fuse.Timespec{Sec: entry.Time})
 				if err == 0 {
 					node.stat.Size = entry.Size
 				}

--- a/src/duplicacy_mount.go
+++ b/src/duplicacy_mount.go
@@ -418,7 +418,8 @@ func calculateChunkReadParams(chunkLengths []int, file *mountChunkInfo, ofst int
 	if params.chunkIndex == file.EndChunk {
 		params.end = file.EndOffset
 		if params.end > chunkLengths[params.chunkIndex] {
-			err = errors.New("no data in chunks")
+			err = errors.New("file endoffset greater than chunk length")
+			return
 		}
 	}
 

--- a/src/duplicacy_mount.go
+++ b/src/duplicacy_mount.go
@@ -1,0 +1,342 @@
+package duplicacy
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/winfsp/cgofuse/fuse"
+)
+
+type node_t struct {
+	stat    fuse.Stat_t
+	chld    map[string]*node_t
+	opencnt int
+}
+
+type BackupFS struct {
+	fuse.FileSystemBase
+	snapshots       map[int]*Snapshot
+	manager         *BackupManager
+	lock            sync.Mutex
+	ino             uint64
+	root            *node_t
+	openmap         map[uint64]*node_t
+	initedRevisions map[int]bool
+}
+
+const LOG_ID = "MOUNTING_FILESYSTEM"
+
+func (self *BackupFS) Open(path string, flags int) (errc int, fh uint64) {
+	defer self.synchronize()()
+	return self.openNode(path, false)
+}
+
+func (self *BackupFS) Opendir(path string) (errc int, fh uint64) {
+	defer self.synchronize()()
+	return self.openNode(path, true)
+}
+
+func (self *BackupFS) Getattr(path string, stat *fuse.Stat_t, fh uint64) (errc int) {
+	defer self.synchronize()()
+	self.initRevision(path)
+
+	node := self.getNode(path, fh)
+	if nil == node {
+		return fuse.ENOENT
+	}
+	*stat = node.stat
+	return 0
+}
+
+func (self *BackupFS) Read(path string, buff []byte, ofst int64, fh uint64) (n int) {
+	defer self.synchronize()()
+	node := self.getNode(path, fh)
+	if nil == node {
+		return fuse.ENOENT
+	}
+
+	revision := self.initRevision(path)
+	if revision < 1 {
+		return fuse.ENOENT
+	}
+
+	components := split(path)
+	snapshotPath := strings.Join(components[5:], "/")
+	LOG_INFO(LOG_ID, "Read(path %s, ofst %d, fh %d)", snapshotPath, ofst, fh)
+
+	if ofst > node.stat.Size {
+		ofst = node.stat.Size
+	}
+
+	snapshot := self.snapshots[revision]
+	file := self.manager.SnapshotManager.FindFile(snapshot, snapshotPath, false)
+
+	var readBuffer bytes.Buffer
+	if !self.manager.SnapshotManager.RetrieveFile(
+		snapshot, file, nil,
+		func(chunk []byte) {
+			readBuffer.Write(chunk)
+			LOG_INFO(LOG_ID, "read chunk with size %d", len(chunk))
+		},
+	) {
+		LOG_ERROR(
+			LOG_ID, "File %s is corrupted in snapshot %s at revision %d",
+			snapshotPath, snapshot.ID, snapshot.Revision)
+		return 0
+	}
+
+	n = copy(buff, readBuffer.Bytes()[ofst:])
+
+	return
+}
+
+func (self *BackupFS) Readdir(
+	path string,
+	fill func(name string, stat *fuse.Stat_t, ofst int64) bool,
+	ofst int64,
+	fh uint64,
+) (errc int) {
+	defer self.synchronize()()
+	node := self.openmap[fh]
+	fill(".", &node.stat, 0)
+	fill("..", nil, 0)
+	for name, chld := range node.chld {
+		if !fill(name, &chld.stat, 0) {
+			break
+		}
+	}
+	return 0
+}
+
+func (self *BackupFS) synchronize() func() {
+	self.lock.Lock()
+	return func() {
+		self.lock.Unlock()
+	}
+}
+
+func (self *BackupFS) getNode(path string, fh uint64) *node_t {
+	if ^uint64(0) == fh {
+		_, _, node := self.lookupNode(path, nil)
+		return node
+	} else {
+		return self.openmap[fh]
+	}
+}
+
+func (self *BackupFS) openNode(path string, dir bool) (int, uint64) {
+	_, _, node := self.lookupNode(path, nil)
+	if nil == node {
+		return fuse.ENOENT, ^uint64(0)
+	}
+	if !dir && fuse.S_IFDIR == node.stat.Mode&fuse.S_IFMT {
+		return fuse.EISDIR, ^uint64(0)
+	}
+	if dir && fuse.S_IFDIR != node.stat.Mode&fuse.S_IFMT {
+		return fuse.ENOTDIR, ^uint64(0)
+	}
+	node.opencnt++
+	if 1 == node.opencnt {
+		self.openmap[node.stat.Ino] = node
+	}
+	return 0, node.stat.Ino
+}
+
+func (self *BackupFS) lookupNode(path string, ancestor *node_t) (prnt *node_t, name string, node *node_t) {
+	prnt = self.root
+	name = ""
+	node = self.root
+	for _, c := range split(path) {
+		if "" != c {
+			prnt, name = node, c
+			if node == nil {
+				return
+			}
+			node = node.chld[c]
+			if nil != ancestor && node == ancestor {
+				name = "" // special case loop condition
+				return
+			}
+		}
+	}
+	return
+}
+
+func (self *BackupFS) makeNode(path string, mode uint32, tmsp fuse.Timespec) (*node_t, int) {
+	prnt, name, node := self.lookupNode(path, nil)
+	if nil == prnt {
+		return nil, fuse.ENOENT
+	}
+	if nil != node {
+		return nil, fuse.EEXIST
+	}
+	self.ino++
+	node = makeNode(self.ino, mode, tmsp)
+	prnt.chld[name] = node
+	return node, 0
+}
+
+func (self *BackupFS) initRoot() {
+	if self.root != nil {
+		return
+	}
+
+	self.openmap = map[uint64]*node_t{}
+
+	revisions, err := self.manager.SnapshotManager.ListSnapshotRevisions(self.manager.snapshotID)
+	if err != nil {
+		LOG_ERROR(LOG_ID, "Failed to list all revisions for snapshot %s: %v", self.manager.snapshotID, err)
+		return
+	}
+
+	LOG_INFO(LOG_ID, "Found %v revisions", len(revisions))
+
+	alreadyCreated := make(map[string]bool)
+
+	const DIR_MODE = fuse.S_IFDIR | 00555
+
+	self.ino++
+	self.root = makeNode(self.ino, DIR_MODE, fuse.Timespec{})
+	self.snapshots = make(map[int]*Snapshot)
+
+	for _, revision := range revisions {
+		snapshot := self.manager.SnapshotManager.DownloadSnapshot(self.manager.snapshotID, revision)
+		self.snapshots[revision] = snapshot
+
+		creationTime := time.Unix(snapshot.StartTime, 0)
+
+		year := strconv.Itoa(creationTime.Year())
+		yearPath := fmt.Sprintf("/%s", year)
+		if !alreadyCreated[yearPath] {
+			date := time.Date(creationTime.Year(), 1, 1, 0, 0, 0, 0, time.Local)
+			self.makeNode(yearPath, DIR_MODE, fuse.Timespec{Sec: date.Unix()})
+			alreadyCreated[yearPath] = true
+		}
+
+		month := fmt.Sprintf("%02d", int(creationTime.Month()))
+		monthPath := fmt.Sprintf("%s/%s", yearPath, month)
+		if !alreadyCreated[monthPath] {
+			date := time.Date(creationTime.Year(), creationTime.Month(), 1, 0, 0, 0, 0, time.Local)
+			self.makeNode(monthPath, DIR_MODE, fuse.Timespec{Sec: date.Unix()})
+			alreadyCreated[monthPath] = true
+		}
+
+		day := fmt.Sprintf("%02d", creationTime.Day())
+		dayPath := fmt.Sprintf("%s/%s", monthPath, day)
+		if !alreadyCreated[dayPath] {
+			date := time.Date(creationTime.Year(), creationTime.Month(), creationTime.Day(), 0, 0, 0, 0, time.Local)
+			self.makeNode(dayPath, DIR_MODE, fuse.Timespec{Sec: date.Unix()})
+			alreadyCreated[dayPath] = true
+		}
+
+		dirname := fmt.Sprintf(
+			"%02d%02d.%d",
+			creationTime.Hour(), creationTime.Minute(), revision)
+		dirPath := fmt.Sprintf("%s/%s", dayPath, dirname)
+		date := time.Date(creationTime.Year(), creationTime.Month(), creationTime.Day(), creationTime.Hour(), creationTime.Minute(), 0, 0, time.Local)
+		self.makeNode(dirPath, DIR_MODE, fuse.Timespec{Sec: date.Unix()})
+	}
+}
+
+func (self *BackupFS) initRevision(path string) (ret int) {
+	self.initRoot()
+
+	if self.initedRevisions == nil {
+		self.initedRevisions = map[int]bool{}
+	}
+
+	ret = -1
+
+	components := split(path)
+	if len(components) < 5 {
+		return
+	}
+
+	dirComponents := strings.Split(components[4], ".")
+	if len(dirComponents) != 2 {
+		return
+	}
+
+	revision, err := strconv.Atoi(dirComponents[1])
+	if err != nil {
+		return
+	}
+
+	ret = revision
+
+	if self.initedRevisions[revision] {
+		return
+	}
+
+	LOG_INFO(LOG_ID, "initRevision %d", revision)
+
+	snapshot := self.snapshots[revision]
+	if snapshot == nil {
+		LOG_INFO(LOG_ID, "Snapshot revision not found")
+		return
+	}
+
+	if !self.manager.SnapshotManager.DownloadSnapshotSequences(snapshot) {
+		LOG_INFO(LOG_ID, "Snapshot sequences download failed")
+		return
+	}
+
+	root := strings.Join(components[:5], "/")
+
+	snapshot.ListRemoteFiles(
+		self.manager.config,
+		self.manager.SnapshotManager.chunkOperator,
+		func(entry *Entry) bool {
+			if entry.Mode&0o20000000000 == 0o20000000000 {
+				self.makeNode(fmt.Sprintf("%s/%s", root, entry.Path), fuse.S_IFDIR|(entry.Mode&00555), fuse.Timespec{Sec: entry.Time})
+			} else {
+				node, err := self.makeNode(fmt.Sprintf("%s/%s", root, entry.Path), entry.Mode&00555, fuse.Timespec{Sec: entry.Time})
+				if err == 0 {
+					node.stat.Size = entry.Size
+				}
+			}
+			return true
+		})
+
+	self.initedRevisions[revision] = true
+
+	return
+}
+
+func makeNode(ino uint64, mode uint32, tmsp fuse.Timespec) *node_t {
+	self := node_t{
+		stat: fuse.Stat_t{
+			Ino:      ino,
+			Mode:     mode,
+			Nlink:    1,
+			Mtim:     tmsp,
+			Birthtim: tmsp,
+		},
+	}
+	if fuse.S_IFDIR == self.stat.Mode&fuse.S_IFMT {
+		self.chld = map[string]*node_t{}
+	}
+	return &self
+}
+
+func split(path string) []string {
+	return strings.Split(path, "/")
+}
+
+func MountFileSystem(fsPath string, manager *BackupManager) {
+	LOG_INFO(LOG_ID, "Mounting snapshot %s on %s", manager.snapshotID, fsPath)
+
+	fs := BackupFS{
+		manager: manager,
+	}
+
+	host := fuse.NewFileSystemHost(&fs)
+	host.SetCapReaddirPlus(true)
+	host.Mount(fsPath, nil)
+
+	return
+}

--- a/src/duplicacy_mount_test.go
+++ b/src/duplicacy_mount_test.go
@@ -181,4 +181,32 @@ func TestCalculateChunkReadParams(t *testing.T) {
 
 		assert(t, AssertVal{res, err}, AssertVal{mountReadParams{2, 17, 98}, nil})
 	}
+
+	{
+		res, err := calculateChunkReadParams(
+			[]int{5361544, 19, 5361544, 5361544},
+			&mountChunkInfo{
+				StartChunk:  1,
+				StartOffset: 0,
+				EndChunk:    1,
+				EndOffset:   19,
+			},
+			19)
+
+		assert(t, AssertVal{res, err}, AssertVal{mountReadParams{1, 19, 19}, nil})
+	}
+
+	{
+		res, err := calculateChunkReadParams(
+			[]int{5361544, 19, 5361544, 5361544},
+			&mountChunkInfo{
+				StartChunk:  1,
+				StartOffset: 0,
+				EndChunk:    1,
+				EndOffset:   19,
+			},
+			5361544)
+
+		assert(t, AssertVal{res, err}, AssertVal{mountReadParams{1, 19, 19}, nil})
+	}
 }

--- a/src/duplicacy_mount_test.go
+++ b/src/duplicacy_mount_test.go
@@ -1,0 +1,184 @@
+package duplicacy
+
+import "testing"
+
+type AssertVal struct {
+	result mountReadParams
+	err    error
+}
+
+func assert(t *testing.T, result AssertVal, expected AssertVal) {
+	if result != expected {
+		t.Errorf("failed: %v != %v", result, expected)
+	}
+}
+
+func TestCalculateChunkReadParams(t *testing.T) {
+	{
+		_, err := calculateChunkReadParams([]int{}, &mountChunkInfo{}, 0)
+		if err == nil {
+			t.Errorf("should error on empty chunkLengths")
+		}
+	}
+
+	{
+		_, err := calculateChunkReadParams(
+			[]int{0},
+			&mountChunkInfo{
+				EndChunk: 3,
+			},
+			0)
+		if err == nil {
+			t.Errorf("should error on chunkLengths being too small")
+		}
+	}
+
+	{
+		_, err := calculateChunkReadParams(
+			[]int{0},
+			&mountChunkInfo{},
+			-1)
+		if err == nil {
+			t.Errorf("should error on negative ofst")
+		}
+	}
+
+	{
+		_, err := calculateChunkReadParams(
+			[]int{10, 20},
+			&mountChunkInfo{
+				EndChunk:  1,
+				EndOffset: 25,
+			},
+			11)
+		if err == nil {
+			t.Errorf("should error on EndOffset greater than chunk length")
+		}
+	}
+
+	{
+		res, err := calculateChunkReadParams(
+			[]int{45, 37, 98},
+			&mountChunkInfo{
+				StartChunk:  0,
+				StartOffset: 5,
+				EndChunk:    0,
+				EndOffset:   15,
+			},
+			0)
+
+		assert(t, AssertVal{res, err}, AssertVal{mountReadParams{0, 5, 15}, nil})
+	}
+
+	{
+		res, err := calculateChunkReadParams(
+			[]int{45, 37, 98},
+			&mountChunkInfo{
+				StartChunk:  0,
+				StartOffset: 5,
+				EndChunk:    0,
+				EndOffset:   15,
+			},
+			4)
+
+		assert(t, AssertVal{res, err}, AssertVal{mountReadParams{0, 9, 15}, nil})
+	}
+
+	{
+		res, err := calculateChunkReadParams(
+			[]int{45, 37, 98},
+			&mountChunkInfo{
+				StartChunk:  0,
+				StartOffset: 5,
+				EndChunk:    1,
+				EndOffset:   15,
+			},
+			0)
+
+		assert(t, AssertVal{res, err}, AssertVal{mountReadParams{0, 5, 45}, nil})
+	}
+
+	{
+		res, err := calculateChunkReadParams(
+			[]int{45, 37, 98},
+			&mountChunkInfo{
+				StartChunk:  0,
+				StartOffset: 5,
+				EndChunk:    1,
+				EndOffset:   15,
+			},
+			4)
+
+		assert(t, AssertVal{res, err}, AssertVal{mountReadParams{0, 9, 45}, nil})
+	}
+
+	{
+		res, err := calculateChunkReadParams(
+			[]int{45, 37, 98},
+			&mountChunkInfo{
+				StartChunk:  0,
+				StartOffset: 5,
+				EndChunk:    1,
+				EndOffset:   15,
+			},
+			45)
+
+		assert(t, AssertVal{res, err}, AssertVal{mountReadParams{1, 5, 15}, nil})
+	}
+
+	{
+		res, err := calculateChunkReadParams(
+			[]int{45, 37, 98},
+			&mountChunkInfo{
+				StartChunk:  0,
+				StartOffset: 5,
+				EndChunk:    1,
+				EndOffset:   15,
+			},
+			40)
+
+		assert(t, AssertVal{res, err}, AssertVal{mountReadParams{1, 0, 15}, nil})
+	}
+
+	{
+		res, err := calculateChunkReadParams(
+			[]int{45, 37, 98},
+			&mountChunkInfo{
+				StartChunk:  0,
+				StartOffset: 5,
+				EndChunk:    1,
+				EndOffset:   15,
+			},
+			60)
+
+		assert(t, AssertVal{res, err}, AssertVal{mountReadParams{1, 15, 15}, nil})
+	}
+
+	{
+		res, err := calculateChunkReadParams(
+			[]int{45, 37, 98},
+			&mountChunkInfo{
+				StartChunk:  1,
+				StartOffset: 7,
+				EndChunk:    2,
+				EndOffset:   96,
+			},
+			0)
+
+		assert(t, AssertVal{res, err}, AssertVal{mountReadParams{1, 7, 37}, nil})
+	}
+
+	{
+		res, err := calculateChunkReadParams(
+			[]int{45, 37, 98},
+			&mountChunkInfo{
+				StartChunk:  0,
+				StartOffset: 0,
+				EndChunk:    2,
+				EndOffset:   98,
+			},
+			99)
+
+		assert(t, AssertVal{res, err}, AssertVal{mountReadParams{2, 17, 98}, nil})
+	}
+}


### PR DESCRIPTION
This work is inspired by [!628](https://github.com/gilbertchen/duplicacy/pull/628), but it's a more complete implementation.

I'm using [cgofuse](https://github.com/winfsp/cgofuse) so it works on all platforms, including Windows.

The command is just `duplicacy mount POINT`, no revision needed. When you run it for the first time, it'll load the list of revisions and create a base tree organizing them by date using the format `/%YYYY/%MM/%DD/%HH%mm.%REV`. For instance, let's say you have this output from `duplicacy list`:

```
$ duplicacy list
Snapshot Users revision 1 created at 2022-10-19 20:09 -hash
Snapshot Users revision 2 created at 2022-10-19 21:38
Snapshot Users revision 3 created at 2022-10-20 10:38
Snapshot Users revision 4 created at 2022-11-14 13:44
```

The following base tree will be created:

```
2022/
    10/
        19/
            2009.1/
            2138.2/
        20/
            1038.3/
    11/
        14/
            1344.4/
```

There're a couple of reasons for that:

- If you have thousands of revisions, they would make a huge single list
- When you open a folder on Windows explorer, it'll try to list the contents of the next level, which would be bad if all revisions were on the same level
- The revision number is appended to avoid collision for revisions created at the same `HH:mm`

After the initial structure is created, the program will lazily load and create the file structure when you try to list the contents of (or access a file in) one of revision folders for the first time, then it'll be cached until program end.

Folders and files will display their saved attributes, with the caveat that everything that's not a folder is shown as a regular file.

File reading is efficiently implemented by only downloading the chunks needed for the specific OS read request and caching them. The cache is a 2Q LRU cache by [golang-lru](https://pkg.go.dev/github.com/hashicorp/golang-lru#TwoQueueCache) with size 20 and keyed by the chunk hash.

I've tested using a repository with these characteristics:

- 10.2 GB
- 70151 Files
- 10467 Folders
- 4 revisions
- sftp storage on a remote server

It takes a couple of seconds to create the base tree and a few seconds for every revision dir that is loaded for the first time, but otherwise everything works as expected.