### PR TITLE
Multithreaded chunk file listing for OneDrive (with batching support)

### DIFF
--- a/src/duplicacy_onestorage.go
+++ b/src/duplicacy_onestorage.go
@@ -8,24 +8,41 @@ import (
 	"fmt"
 	"path"
 	"strings"
+	"sync"
 )
 
 type OneDriveStorage struct {
 	StorageBase
 
-	client         *OneDriveClient
-	storageDir     string
-	numberOfThread int
+	client          *OneDriveClient
+	storageDir      string
+	numberOfThreads int
 }
 
 // CreateOneDriveStorage creates an OneDrive storage object.
-func CreateOneDriveStorage(tokenFile string, isBusiness bool, storagePath string, threads int, client_id string, client_secret string, drive_id string) (storage *OneDriveStorage, err error) {
+func CreateOneDriveStorage(
+	tokenFile string, 
+	isBusiness bool, 
+	storagePath string, 
+	threads int, 
+	max_batch_requests int, 
+	client_id string, 
+	client_secret string, 
+	drive_id string,
+) (storage *OneDriveStorage, err error) {
 
 	for len(storagePath) > 0 && storagePath[len(storagePath)-1] == '/' {
 		storagePath = storagePath[:len(storagePath)-1]
 	}
 
-	client, err := NewOneDriveClient(tokenFile, isBusiness, client_id, client_secret, drive_id)
+	client, err := NewOneDriveClient(
+		tokenFile, 
+		isBusiness, 
+		max_batch_requests, 
+		client_id, 
+		client_secret, 
+		drive_id,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -44,9 +61,9 @@ func CreateOneDriveStorage(tokenFile string, isBusiness bool, storagePath string
 	}
 
 	storage = &OneDriveStorage{
-		client:         client,
-		storageDir:     storagePath,
-		numberOfThread: threads,
+		client:          client,
+		storageDir:      storagePath,
+		numberOfThreads: threads,
 	}
 
 	for _, path := range []string{"chunks", "fossils", "snapshots"} {
@@ -78,8 +95,9 @@ func (storage *OneDriveStorage) convertFilePath(filePath string) string {
 	return filePath
 }
 
+
 // ListFiles return the list of files and subdirectories under 'dir' (non-recursively)
-func (storage *OneDriveStorage) ListFiles(threadIndex int, dir string) ([]string, []int64, error) {
+func (storage *OneDriveStorage) ListFilesNotThreaded(threadIndex int, dir string) ([]string, []int64, error) {
 
 	for len(dir) > 0 && dir[len(dir)-1] == '/' {
 		dir = dir[:len(dir)-1]
@@ -143,6 +161,140 @@ func (storage *OneDriveStorage) ListFiles(threadIndex int, dir string) ([]string
 		return files, sizes, nil
 	}
 
+}
+
+// ListFiles return the list of files and subdirectories under 'dir' (non-recursively)
+func (storage *OneDriveStorage) ListFiles(threadIndex int, dir string) ([]string, []int64, error) {
+
+	for len(dir) > 0 && dir[len(dir)-1] == '/' {
+		dir = dir[:len(dir)-1]
+	}
+
+	if dir == "snapshots" {
+		// Not threaded
+		entries, err := storage.client.ListEntries(storage.storageDir + "/" + dir)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		subDirs := []string{}
+		for _, entry := range entries {
+			if len(entry.Folder) > 0 {
+				subDirs = append(subDirs, entry.Name+"/")
+			}
+		}
+		return subDirs, nil, nil
+	} else if strings.HasPrefix(dir, "snapshots/") || strings.HasPrefix(dir, "benchmark") {
+		// Not threaded
+		entries, err := storage.client.ListEntries(storage.storageDir + "/" + dir)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		files := []string{}
+
+		for _, entry := range entries {
+			if len(entry.Folder) == 0 {
+				files = append(files, entry.Name)
+			}
+		}
+		return files, nil, nil
+	} else {
+		// Batched and threaded
+		lock := sync.Mutex {}
+		allFiles := []string{}
+		allSizes := []int64{}
+
+		errorChannel := make(chan error)
+		requestChannel := make(chan OneDriveListReqItem)
+		activeWorkers := 0
+
+		requests := []OneDriveListReqItem{
+			{Path:"chunks", 	URL:""},
+			{Path:"fossils", 	URL:""},
+		}
+
+		maxRequestsPerThread := 1
+		if storage.client.MaxBatchReqs > 1 {
+			// OneDrive Business works through Graph API 
+			// which supports batch requests (20 is the max)
+			maxRequestsPerThread = storage.client.MaxBatchReqs
+		}
+
+		for len(requests) > 0 || activeWorkers > 0 {
+			if len(requests) > 0 && activeWorkers < storage.numberOfThreads {
+				n_batchReqs := len(requests)
+				if n_batchReqs > maxRequestsPerThread {
+					n_batchReqs = maxRequestsPerThread
+				}
+				// Dequeue n_batch_reqs from the request queue
+				batchReqs := requests[:n_batchReqs]
+				requests = requests[n_batchReqs:]
+				activeWorkers++
+
+				go func(batchReqs []OneDriveListReqItem) {
+					// Will do non-batching if disabled / not supported
+					entriesPerReq, newReqs, err := storage.client.ListEntriesBatch(storage.storageDir, batchReqs)
+					if err != nil {
+						errorChannel <- err
+						return
+					}
+
+					// send paging requests first
+					for _, pageReq := range newReqs {
+						requestChannel <- pageReq 
+					}
+
+					files := []string {}
+					sizes := []int64 {}
+
+					for i, entries := range entriesPerReq {
+						LOG_DEBUG("ONE_STORAGE", "Listing %s; %d items returned", batchReqs[i].Path, len(entries.Entries))
+						for _, entry := range entries.Entries {
+							if len(entry.Folder) == 0 {
+								name := entry.Name
+								if strings.HasPrefix(batchReqs[i].Path, "fossils") {
+									name = batchReqs[i].Path + "/" + name + ".fsl"
+									name = name[len("fossils/"):]
+								} else {
+									name = batchReqs[i].Path + "/" + name
+									name = name[len("chunks/"):]
+								}
+								files = append(files, name)
+								sizes = append(sizes, entry.Size)
+							} else {
+								recurseDirRequest := OneDriveListReqItem{
+									Path: batchReqs[i].Path + "/" + entry.Name,
+									URL: "",
+								}
+								requestChannel <- recurseDirRequest
+							}
+						}
+					}
+					lock.Lock()
+					allFiles = append(allFiles, files...)
+					allSizes = append(allSizes, sizes...)
+					lock.Unlock()
+					requestChannel <- OneDriveListReqItem{Path:"", URL:""}
+				} (batchReqs)
+			}
+
+			if activeWorkers > 0 {
+				select {
+				case err := <- errorChannel:
+					return nil, nil, err
+				case request := <- requestChannel:
+					if request.Path == "" {
+						activeWorkers--
+					} else {
+						requests = append(requests, request)
+					}
+				}
+			}
+		}
+
+		return allFiles, allSizes, nil
+	}
 }
 
 // DeleteFile deletes the file or directory at 'filePath'.
@@ -211,13 +363,13 @@ func (storage *OneDriveStorage) DownloadFile(threadIndex int, filePath string, c
 
 	defer readCloser.Close()
 
-	_, err = RateLimitedCopy(chunk, readCloser, storage.DownloadRateLimit/storage.numberOfThread)
+	_, err = RateLimitedCopy(chunk, readCloser, storage.DownloadRateLimit/storage.numberOfThreads)
 	return err
 }
 
 // UploadFile writes 'content' to the file at 'filePath'.
 func (storage *OneDriveStorage) UploadFile(threadIndex int, filePath string, content []byte) (err error) {
-	err = storage.client.UploadFile(storage.storageDir+"/"+filePath, content, storage.UploadRateLimit/storage.numberOfThread)
+	err = storage.client.UploadFile(storage.storageDir+"/"+filePath, content, storage.UploadRateLimit/storage.numberOfThreads)
 
 	if e, ok := err.(OneDriveError); ok && e.Status == 409 {
 		LOG_TRACE("ONEDRIVE_UPLOAD", "File %s already exists", filePath)


### PR DESCRIPTION
Added support for multithreaded file chunk listing, with batching support for ODB (Graph API). For more details, see https://forum.duplicacy.com/t/optimizations-for-large-datasets/7233/15.