### PR TITLE
Acquire verifiedChunksLock in saveVerifiedChunks

### DIFF
--- a/src/duplicacy_snapshotmanager.go
+++ b/src/duplicacy_snapshotmanager.go
@@ -1019,6 +1019,8 @@ func (manager *SnapshotManager) CheckSnapshots(snapshotID string, revisionsToChe
 	numberOfVerifiedChunks := len(verifiedChunks)
 
 	saveVerifiedChunks := func() {
+		verifiedChunksLock.Lock()
+		defer verifiedChunksLock.Unlock()
 		if len(verifiedChunks) > numberOfVerifiedChunks {
 			var description []byte
 			description, err = json.Marshal(verifiedChunks)


### PR DESCRIPTION
Lock `verifiedChunksLock` in `saveVerifiedChunks` so that the process doesn't crash with a concurrency error when attempting to write out the `verified_chunks` file on error when verifying chunks.