### PR TITLE
Improve file listing for b2 backend

### DIFF
--- a/src/duplicacy_b2client.go
+++ b/src/duplicacy_b2client.go
@@ -396,7 +396,7 @@ type B2ListFileNamesOutput struct {
 
 func (client *B2Client) ListFileNames(threadIndex int, startFileName string, singleFile bool, includeVersions bool) (files []*B2Entry, err error) {
 
-	maxFileCount := 1000
+	maxFileCount := 10 * 1000
 	if singleFile {
 		if includeVersions {
 			maxFileCount = 4


### PR DESCRIPTION
Both the [b2_list_file_names](https://www.backblaze.com/apidocs/b2-list-file-names) and [b2_list_file_versions](https://www.backblaze.com/apidocs/b2-list-file-versions) api calls may return up to 10k results.
![image](https://github.com/gilbertchen/duplicacy/assets/1352848/9e0da96c-0e72-4f37-b107-8de7bd80e9c6)

By increasing the maxFileCount parameter this PR reduces the time it takes to prune/check a repository.