### PR TITLE
[Bugfix] Backup on Openstack Swift storage fails after 60 seconds

### DIFF
--- a/src/duplicacy_swiftstorage.go
+++ b/src/duplicacy_swiftstorage.go
@@ -24,7 +24,7 @@ type SwiftStorage struct {
 }
 
 // CreateSwiftStorage creates an OpenStack Swift storage object.  storageURL is in the form of
-// `user@authURL/container/path?arg1=value1&arg2=value2``
+// `user@authURL/container/path?arg1=value1&arg2=value2`
 func CreateSwiftStorage(storageURL string, key string, threads int) (storage *SwiftStorage, err error) {
 
 	// This is the map to store all arguments
@@ -108,7 +108,7 @@ func CreateSwiftStorage(storageURL string, key string, threads int) (storage *Sw
 		arguments["protocol"] = "https"
 	}
 
-	ctx, _ := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
+	ctx := context.Background()
 
 	// Please refer to https://godoc.org/github.com/ncw/swift#Connection
 	connection := swift.Connection{


### PR DESCRIPTION
Attempting to make a backup that lasts more than 60 seconds on Openstack Swift storage fails with the error `contextDeadlineExceeded` because the storage context timeout applies to the entire backup session (and not to each request).

There is already a timeout defined in the swift Connection that applies for each request, so I just removed the timeout on the context.

This should also fix the same issue for a restore session or any other long-running commands.