### PR TITLE
Fix xattr name format on Linux

### DIFF
--- a/src/duplicacy_utils_linux.go
+++ b/src/duplicacy_utils_linux.go
@@ -8,6 +8,6 @@ import (
 )
 
 func excludedByAttribute(attirbutes map[string][]byte) bool {
-	_, ok := attirbutes["duplicacy_exclude"]
+	_, ok := attirbutes["user.duplicacy_exclude"]
 	return ok
 }


### PR DESCRIPTION
On Linux `xattr` attribute names must have `namespace.attribute` form. As previously discussed on the [forum](https://forum.duplicacy.com/t/xattr-based-exclusion-on-linux-doesnt-work-because-of-incorrect-xattr-name/5206).